### PR TITLE
update to drawer to stop rollovers on touch devices

### DIFF
--- a/less/drawer.less
+++ b/less/drawer.less
@@ -37,5 +37,9 @@
     }
     .drawer-item-open {
         padding:@drawer-item-padding;
+        //stops rollover of drawar items on touch devices    
+        &.touch:hover {
+             background-color: @drawer-color;
+       }
     }
 }


### PR DESCRIPTION
set drawer item open colour hover state to the variable @drawer-color.
this will stop hover states showing on touch devices.
