### PR TITLE
Externalised padding for .block-inner

### DIFF
--- a/less/block.less
+++ b/less/block.less
@@ -4,7 +4,7 @@
 .block {
     .responsive-layout;
     .block-inner {
-        padding:0px 20px 40px;
+        padding:@block-inner-padding;
     }
     .block-title {
         text-align:left;

--- a/less/variables.less
+++ b/less/variables.less
@@ -216,6 +216,12 @@
 
 @article-body-padding:@article-body-padding-top @article-body-padding-sides @article-body-padding-bottom;
 
+@block-inner-padding-top:0px;
+@block-inner-padding-sides:50px;
+@block-inner-padding-bottom:40px;
+
+@block-inner-padding:@block-inner-padding-top @block-inner-padding-sides @block-inner-padding-bottom;
+
 @block-body-padding-top:0px;
 @block-body-padding-sides:0px;
 @block-body-padding-bottom:0px;


### PR DESCRIPTION
During the course styling I've found that moving the padding of `.block-inner` to `variables.less` is more convenient.