### PR TITLE
Fix for x axis overflow under scrollbar

### DIFF
--- a/less/responsive.less
+++ b/less/responsive.less
@@ -1,6 +1,10 @@
 // Responsive layouts
 // ==================
 
+body {
+    overflow-x: hidden;
+}
+
 .responsive-large {
     @media all and (min-width:@device-width-large) {
         width:@device-width-large;


### PR DESCRIPTION
At the snap-points between mobile and tablet, tablet and desktop the scrollbar appears due to a slight overstretch of the content under the scrollbar. The fix effectively hides this overflow so that the bottom (x-axis) scrollbar never appears.