### PR TITLE
ABU-801, ABU-805, ABU-816 Button padding, notify and drawer fixes

### DIFF
--- a/less/paddings.less
+++ b/less/paddings.less
@@ -76,6 +76,9 @@
 // Buttons	
 @button-padding-top: @button-padding;
 @button-padding-bottom: @button-padding;
+@button-padding-left: @button-padding;
+@button-padding-right: @button-padding;
+
 @button-margin-top: @button-margin;
 @button-margin-bottom: @button-margin;
 

--- a/less/src/adapt-defaults.less
+++ b/less/src/adapt-defaults.less
@@ -132,9 +132,9 @@
 @button-text-disabled-color: #ccc;
 
 // @button-padding-top: 8px;
-@button-padding-right: 10px;
+// @button-padding-right: 10px;
 // @button-padding-bottom: 8px;
-@button-padding-left: 10px;
+// @button-padding-left: 10px;
 
 // @button-padding: @button-padding-top @button-padding-right @button-padding-bottom @button-padding-left;
 

--- a/less/src/buttons.less
+++ b/less/src/buttons.less
@@ -4,7 +4,7 @@
 .button, button {
     background-color: @button-color;
     color: @button-text-color;
-    padding: @button-padding-top 0 @button-padding-bottom;
+    padding: @button-padding-top @button-padding-right+10 @button-padding-bottom @button-padding-left+10; // Added left / right padding in case buttons aren't centrally aligned
     text-decoration: none;
     text-align: center;
     display:inline-block;

--- a/less/src/drawer.less
+++ b/less/src/drawer.less
@@ -12,8 +12,9 @@
     .drawer-toolbar .icon {
         color: @drawer-icon-color;
         padding: @navigation-padding;
+        .transition-color;
 
-        &:hover {
+        .no-touch &:hover {
             color: @drawer-icon-color-hover;
         }
 
@@ -33,7 +34,7 @@
 
     .drawer-item {
         .drawer-item-title {
-            .sub-title
+            .sub-title;
         }
         
         .drawer-item-open {
@@ -50,8 +51,10 @@
 
     .drawer-item-open {
         padding: @drawer-item-padding-top @drawer-item-padding-right @drawer-item-padding-bottom @drawer-item-padding-left;
+        .transition-background-color;
+
         //stops rollover of drawar items on touch devices    
-        &.touch:hover {
+        .no-touch &:hover {
              background-color: @drawer-color;
        }
     }

--- a/less/src/notify.less
+++ b/less/src/notify.less
@@ -121,6 +121,7 @@
 
     .notify-popup-icon-close {
         color: @notify-icon-color;
+        .transition-color;
 
         .no-touch &:hover {
             color: @notify-icon-color-hover;


### PR DESCRIPTION
- ABU-801, ABU-805, ABU-816 should all be fixed by the introduction of left / right padding onto the buttons class (paddings.less, adapt-defaults.less, buttons.less)
- Added transition effect to the drawer close icon and drawer items
- Amended hover state code to include no-touch class
- Added transition effect to the notify close icon