### PR TITLE
ABU-905

### DIFF
--- a/less/src/notify.less
+++ b/less/src/notify.less
@@ -42,7 +42,7 @@
     }
 
     .notify-popup-content-inner {
-        padding-left: 80px;
+        padding-left: 0px;
 
         .dir-rtl & {
             padding-left: inherit;


### PR DESCRIPTION
removed padding-left from notify. not sure why it was added, but with it, the notify content is not center aligned to the screen.