### PR TITLE
hide checkboxes

### DIFF
--- a/less/src/gmcq.less
+++ b/less/src/gmcq.less
@@ -161,6 +161,7 @@
     }
 
     .gmcq-item input {
+        opacity: 0;
         position:absolute;
         bottom:14px;
         left:25px;


### PR DESCRIPTION
this fix hides the checkboxes of the gmcq without affecting the tab order