### PR TITLE
ABU-795

### DIFF
--- a/less/src/matching.less
+++ b/less/src/matching.less
@@ -64,6 +64,17 @@
 }
 
 .no-touch {
+  .matching-select-icon {
+    &:hover {
+      color: @item-text-color-hover;
+      &.matching-correct-icon {
+        color: @validation-success;
+      }
+      &.matching-incorrect-icon {
+        color: @validation-error;
+      }
+    }
+  }
   .matching-select-container {
     &:hover {
       background-color: @item-color-hover;


### PR DESCRIPTION
validation colors applied on hover state of select-icon

reimplementation of Kirsty's fix:
https://github.com/adaptlearning/adapt-contrib-vanilla/commit/3a50af6f721d3d529f63d1820c21b4abc494d5c0#diff-0