### PR TITLE
Drawer Font Size Amend

### DIFF
--- a/less/src/drawer.less
+++ b/less/src/drawer.less
@@ -35,6 +35,7 @@
         
         .drawer-item-description {
         	font-size: @body-text-font-size;
+        	line-height: @body-text-line-height;
         }
         
         .drawer-item-open {

--- a/less/src/drawer.less
+++ b/less/src/drawer.less
@@ -33,6 +33,10 @@
             .sub-title;
         }
         
+        .drawer-item-description {
+        	font-size: @body-text-font-size;
+        }
+        
         .drawer-item-open {
             border-bottom: 1px solid @drawer-item-color;
             color: @drawer-item-text-color;


### PR DESCRIPTION
Set the font size of the drawer description to the same as the body.

Text was being overwritten by the <a> to <button> change.