### PR TITLE
Wrapped component.hbs with div tags

### DIFF
--- a/templates/partials/component.hbs
+++ b/templates/partials/component.hbs
@@ -1,21 +1,29 @@
-{{#if displayTitle}}
-	<div class="{{_component}}-title component-title">
-	    <div role="heading" tabindex="0" class="{{_component}}-title-inner component-title-inner"  aria-level="4">
-	        {{{displayTitle}}}
-	    </div>
-	</div>
-{{/if}}
-{{#if body}}
-	<div class="{{_component}}-body component-body">
-	    <div class="{{_component}}-body-inner component-body-inner">
-	        {{{a11y_text body}}}
-	    </div>
-	</div>
-{{/if}}
-{{#if instruction}}
-	<div class="{{_component}}-instruction component-instruction">
-	    <div class="{{_component}}-instruction-inner component-instruction-inner">
-	        {{{a11y_text instruction}}}
-	    </div>
-	</div>
-{{/if}}
+<div class="{{_component}}-header component-header">
+    <div class="{{_component}}-header-inner component-header-inner">
+
+        {{#if displayTitle}}
+        <div class="{{_component}}-title component-title">
+            <div role="heading" tabindex="0" class="{{_component}}-title-inner component-title-inner"  aria-level="4">
+                {{{displayTitle}}}
+            </div>
+        </div>
+        {{/if}}
+        
+        {{#if body}}
+        <div class="{{_component}}-body component-body">
+            <div class="{{_component}}-body-inner component-body-inner">
+                {{{a11y_text body}}}
+            </div>
+        </div>
+        {{/if}}
+        
+        {{#if instruction}}
+        <div class="{{_component}}-instruction component-instruction">
+            <div class="{{_component}}-instruction-inner component-instruction-inner">
+                {{{a11y_text instruction}}}
+            </div>
+        </div>
+        {{/if}}
+
+    </div>
+</div>


### PR DESCRIPTION
Surrounded component title, body, and instruction elements in a wrapper div + inner.

Added {{_component}} to wrapper divs to allow for specific component styling.

Un-themed divs by default, implemented to give course authors an easier time if they'd like to give component headings a background.

https://github.com/adaptlearning/adapt_framework/issues/965