### PR TITLE
Created body-text mixin

### DIFF
--- a/less/src/fonts.less
+++ b/less/src/fonts.less
@@ -100,6 +100,12 @@ body {
     line-height: @instruction-text-line-height;
 }
 
+.body-text {
+    font-size: @body-text-font-size;
+    font-weight: @body-text-font-weight;
+    line-height: @body-text-line-height;
+}
+
 .notify-popup-title {
     font-size: @component-title-font-size;
     font-weight: @component-title-font-weight;


### PR DESCRIPTION
A body text mixin can be used when overriding fields like attribution text if you wish to easily style it like regular text.