### PR TITLE
Bug fix, IE8 nav central alignment

### DIFF
--- a/less/src/navigation.less
+++ b/less/src/navigation.less
@@ -10,6 +10,8 @@
 
     .ie8 & {
         max-width: @ie8-max-width;
+        left: 0;
+        right: 0;
     }
 
     .icon {


### PR DESCRIPTION
Aligns the navigation bar centrally over the content in IE8

Fixes this bug https://github.com/adaptlearning/adapt_framework/issues/1579 