### PR TITLE
Support for blockquote

### DIFF
--- a/less/src/component.less
+++ b/less/src/component.less
@@ -10,7 +10,7 @@
         }
     }
 
-    .component-title{
+    .component-title {
         margin-bottom: @component-title-margin-bottom;
         color: @title-color;
         text-align: left;
@@ -24,16 +24,22 @@
         padding: 0px;
     }
 
-    .component-body{
+    .component-body {
         margin: @component-body-margin-top 0px @component-body-margin-bottom;
 
         a {
-          text-decoration: underline;
-          color: @font-color;
+            text-decoration: underline;
+            color: @font-color;
+        }
+        
+        blockquote {
+            border-left: 2px solid @primary-color;
+            margin-left: 20px;
+            padding-left: 20px;
         }
     }
 
-    .component-body-inner{
+    .component-body-inner {
         padding: 0px;
     }
 

--- a/less/src/component.less
+++ b/less/src/component.less
@@ -31,12 +31,6 @@
             text-decoration: underline;
             color: @font-color;
         }
-        
-        blockquote {
-            border-left: 2px solid @primary-color;
-            margin-left: 20px;
-            padding-left: 20px;
-        }
     }
 
     .component-body-inner {

--- a/less/src/theme-extras.less
+++ b/less/src/theme-extras.less
@@ -92,3 +92,11 @@
 		background-image: none;
 	}
 }
+
+// Adds styling to the blockquote element.
+
+blockquote {
+    border-left: 2px solid @primary-color;
+    margin-left: 20px;
+    padding-left: 20px;
+}


### PR DESCRIPTION
blockquote is a button that is used in CKEditor (the text editor used in the AT) so it makes sense to add support for it in vanilla.

Also fixed indentations and spacing before braces