### PR TITLE
Non-mobile replacing no-touch

### DIFF
--- a/less/generic.less
+++ b/less/generic.less
@@ -7,6 +7,10 @@
 @device-width-medium: unit(@adapt-device-medium, px);
 @device-width-large: unit(@adapt-device-large, px);
 
+// Mobile operating systems
+// ==========
+@non-mobile: ~"html:not(.os-ios):not(.os-android)";
+
 // Max-widths
 // ==========
 

--- a/less/generic.less
+++ b/less/generic.less
@@ -7,7 +7,7 @@
 @device-width-medium: unit(@adapt-device-medium, px);
 @device-width-large: unit(@adapt-device-large, px);
 
-// Mobile operating systems
+// Non-mobile operating systems
 // ==========
 @non-mobile: ~"html:not(.os-ios):not(.os-android)";
 

--- a/less/src/accordion.less
+++ b/less/src/accordion.less
@@ -43,7 +43,7 @@
                 color: @item-text-color-selected;
             }
         }
-        .no-touch & {
+        @{non-mobile} & {
             &:hover {
                 color: @item-text-color-hover;
                 background-color: @item-color-hover;

--- a/less/src/buttons.less
+++ b/less/src/buttons.less
@@ -13,13 +13,13 @@
     .transition-all-colors;
     .button-text;
 
-    .no-touch &:hover {
+    &:hover {
         background-color: @button-color-hover;
         color: @button-text-color-hover;
         border-color: @button-border-color-hover;
     }
 
-    &.base { 
+    &.base {
     	// Override button styles on <a> tags coverted to <button> tags
     	// Could be improved so that buttons are divided into groups, default / submit / nav / icon
     	background-color: transparent;
@@ -30,10 +30,10 @@
         -ms-transition: none;
         transition: none;
 
-    	.no-touch &:hover {
+    	@{non-mobile} &:hover {
     		background-color: transparent;
     	}
-    	
+
     	.dir-rtl & {
     		text-align: right;
     	}
@@ -45,7 +45,7 @@
         color: @button-text-color-disabled!important;
         cursor:default;
 
-        .no-touch &:hover {
+        @{non-mobile} &:hover {
             border-color: @button-border-color-disabled;
         }
     }
@@ -116,7 +116,7 @@
             margin-right: -(40px/2);
             right: 50%;
         }
-        
+
         &.icon-tick {
             background-color: @validation-success;
         }

--- a/less/src/buttons.less
+++ b/less/src/buttons.less
@@ -13,7 +13,7 @@
     .transition-all-colors;
     .button-text;
 
-    &:hover {
+    @{non-mobile} &:hover {
         background-color: @button-color-hover;
         color: @button-text-color-hover;
         border-color: @button-border-color-hover;

--- a/less/src/drawer.less
+++ b/less/src/drawer.less
@@ -17,7 +17,7 @@
         padding: @navigation-padding;
         .transition-color;
 
-        .no-touch &:hover {
+        @{non-mobile} &:hover {
             color: @drawer-icon-color-hover;
         }
     }
@@ -51,7 +51,7 @@
             text-decoration: none;
             width: 100%;
             
-            .no-touch &:hover {
+            @{non-mobile} &:hover {
                 background-color: @drawer-item-color-hover;
                 color: @drawer-item-text-color-hover;
             }
@@ -63,7 +63,7 @@
         .transition-background-color;
 
         //stops rollover of drawar items on touch devices    
-        .no-touch &:hover {
+        @{non-mobile} &:hover {
              background-color: @drawer-color;
        }
     }

--- a/less/src/focus.less
+++ b/less/src/focus.less
@@ -1,7 +1,7 @@
 .focused,
 *:focus,
 input:focus + label {
-    .accessibility.no-touch & {
+    .accessibility@{non-mobile} & {
         outline: @focus-outline;
     }
 }

--- a/less/src/focus.less
+++ b/less/src/focus.less
@@ -1,7 +1,7 @@
 .focused,
 *:focus,
 input:focus + label {
-    .accessibility@{non-mobile} & {
+    @{non-mobile}.accessibility & {
         outline: @focus-outline;
     }
 }

--- a/less/src/gmcq.less
+++ b/less/src/gmcq.less
@@ -140,7 +140,7 @@
     }
 }
 
-.no-touch {
+@{non-mobile} {
     .gmcq-component {
         .gmcq-widget {
             &:not(.disabled) {

--- a/less/src/hotgraphic.less
+++ b/less/src/hotgraphic.less
@@ -8,7 +8,7 @@
 				color: @item-color-visited;
 			}
 		}
-		.no-touch &:hover {
+		@{non-mobile} &:hover {
 			background-color: @item-text-color;
 			
 			.hotgraphic-graphic-pin-icon {
@@ -35,7 +35,7 @@
 	}
 
 	.hotgraphic-popup-done {
-		.no-touch &:hover {
+		@{non-mobile} &:hover {
 			.hotgraphic-popup-close {
 				color: @button-text-color-hover;
 			}
@@ -55,7 +55,7 @@
 	}
 
 	.hotgraphic-popup-controls {
-		.no-touch &:hover {
+		@{non-mobile} &:hover {
 			.hotgraphic-popup-arrow-l,
 			.hotgraphic-popup-arrow-r {
 				color: @button-text-color-hover;

--- a/less/src/matching.less
+++ b/less/src/matching.less
@@ -25,7 +25,7 @@
 
 
 			&:hover {
-				.no-touch & {
+				@{non-mobile} & {
 					background-color: @item-color-hover;
 					color: @item-text-color-hover;
 				}
@@ -58,7 +58,7 @@
 	}
 }
 
-.no-touch {
+@{non-mobile} {
 	.matching-select-icon {
 		&:hover {
 			color: @item-text-color-hover;
@@ -87,7 +87,7 @@
 
 	&.select2-container--disabled {
 		span.select2-selection--single,
-		.no-touch & span.select2-selection--single:hover {
+		@{non-mobile} & span.select2-selection--single:hover {
 			background-color: @item-color-disabled;
 			color: @item-text-color-disabled;
 		}

--- a/less/src/mcq.less
+++ b/less/src/mcq.less
@@ -109,7 +109,7 @@
     }
 }
 
-.no-touch {
+@{non-mobile} {
 
     .mcq-widget {
         &:not(.disabled) {

--- a/less/src/navigation.less
+++ b/less/src/navigation.less
@@ -19,7 +19,7 @@
         color: @navigation-icon-color;
         .transition-color;
 
-        .no-touch &:hover {
+        @{non-mobile} &:hover {
             color: @navigation-icon-color-hover;
         }
     }

--- a/less/src/notify.less
+++ b/less/src/notify.less
@@ -115,7 +115,7 @@
         .transition-all-colors;
         .button-text;
         
-        .no-touch &:hover {
+        @{non-mobile} &:hover {
             background-color: @notify-button-color-hover;
             color: @notify-button-text-color-hover;
         }
@@ -131,7 +131,7 @@
         right:0px;
         .transition-border-color;
 
-        .no-touch &:hover {
+        @{non-mobile} &:hover {
             border-color: @notify-icon-color-hover;
 
             .notify-popup-icon-close {
@@ -149,7 +149,7 @@
         color: @notify-icon-color;
         .transition-color;
 
-        .no-touch &:hover {
+        @{non-mobile} &:hover {
             color: @notify-icon-color-hover;
         }
     }
@@ -227,7 +227,7 @@
     .icon {
         color: @notify-icon-color;
         
-        .no-touch &:hover {
+        @{non-mobile} &:hover {
             color: @notify-icon-color-hover;
         }
     }

--- a/less/src/page-level-progress.less
+++ b/less/src/page-level-progress.less
@@ -5,7 +5,7 @@
     padding:  @navigation-padding!important; // Override defaults in extension
     margin: 5px 0;
     
-    .no-touch &:hover {
+    @{non-mobile} &:hover {
 
         .page-level-progress-navigation-completion {
             background-color: @navigation-progress-background-color-hover;
@@ -65,7 +65,7 @@
     		font-size: @button-text-font-size;
 	        font-weight: @font-weight-light;
 
-            .no-touch &:hover {
+            @{non-mobile} &:hover {
                 background-color: @drawer-item-color-disabled;
                 color: @drawer-item-text-color-disabled;
                 .page-level-progress-indicator {
@@ -74,7 +74,7 @@
             }
     	}
 
-        .no-touch &:hover {
+        @{non-mobile} &:hover {
             background-color: @drawer-item-color-hover;
             color: @drawer-item-text-color-hover;
 

--- a/less/src/resources.less
+++ b/less/src/resources.less
@@ -18,7 +18,7 @@
             border-bottom: 1px solid @drawer-item-color-selected;
         }
 
-        .no-touch &:hover {
+        @{non-mobile} &:hover {
             color:  @drawer-item-text-color-hover;
             background-color: @drawer-item-color-hover;
             border-bottom: 1px solid @drawer-item-color-hover;

--- a/less/src/slider.less
+++ b/less/src/slider.less
@@ -23,7 +23,7 @@
         .rangeslider__handle {
           background-color: @item-color;
           &:hover {
-            .no-touch & {
+            @{non-mobile} & {
               background-color: @item-color-hover;
             }
           }


### PR DESCRIPTION
`no-touch` is problematic as it's applied on desktop operating systems that have a touch screen, which is a good proportion of Windows laptops released in the last three years. These users are more likely using a trackpad or mouse to navigate a course then their touchscreen - though this is open to debate.

This PR creates a variable which `os-android` and `os-ios` which makes >99% of the market share of mobile OS.

Original issue - https://github.com/adaptlearning/adapt_framework/issues/1820