### PR TITLE
accessibility: issue/#2083 updated plp styling for completion indicators

### DIFF
--- a/less/colors.less
+++ b/less/colors.less
@@ -127,9 +127,9 @@
 // Menu
 @menu-item-color: @primary-color;
 @menu-item-text-color: @primary-color-inverted;
-@menu-item-progress-color: darken(@menu-item-color, 20%);
-@menu-item-progress-fill-color: @menu-item-text-color;
-@menu-item-progress-border-color: transparent;
+@menu-item-progress-color: @navigation-color;
+@menu-item-progress-fill-color: @navigation-icon-color;
+@menu-item-progress-border-color: @navigation-icon-color;
 
 // Notify
 @notify-color: @primary-color;

--- a/less/src/boxmenu.less
+++ b/less/src/boxmenu.less
@@ -92,7 +92,7 @@
 
 	.page-level-progress-menu-item {
 		width: 60px;
-		height: 6px;
+		height: 12px;
 		float: none;
 		padding: 0;
 		position: absolute;
@@ -107,17 +107,26 @@
 
 	.page-level-progress-menu-item-indicator {
 		width: 60px;
-		height: 6px;
+		height: 8px;
 		background-color: @menu-item-progress-color;
 		border: 2px solid @menu-item-progress-border-color;
-		border-radius: 25px;
+		border-radius: 50px;
 	}
 
 	.page-level-progress-menu-item-indicator-bar {
-		height: 6px;
+		height: 8px;
 		background-color: @menu-item-progress-fill-color;
-		border-radius: 25px;
 	}
+
+	.page-level-progress-completion-indicator {
+			background-color: @menu-item-progress-color;
+			border-color: @menu-item-progress-border-color;
+	}
+
+	.page-level-progress-completion-inner-indicator {
+			background-color: @menu-item-progress-fill-color;
+	}
+
 
 	.menu-item-duration {
 		position: absolute;

--- a/less/src/boxmenu.less
+++ b/less/src/boxmenu.less
@@ -110,8 +110,11 @@
 	}
 
 	.pagelevelprogress-indicator-inner {
-		background-color: @menu-item-progress-fill-color;
 		border-color: @menu-item-progress-color;
+	}
+
+	.pagelevelprogress-indicator-bar {
+		background-color: @menu-item-progress-fill-color;
 	}
 
 	.menu-item-duration {

--- a/less/src/navigation.less
+++ b/less/src/navigation.less
@@ -1,12 +1,13 @@
 // Navigation styling
 // ==================
+@navigation-height: (@navigation-padding * 2) + @icon-size;
 
 .navigation {
     width: 100%;
     overflow: hidden;
     background-color: @navigation-color;
     box-shadow: 0 2px 5px rgba(0,0,0,0.26);
-    height: (@navigation-padding * 2) + @icon-size;
+    height: @navigation-height;
 
     .ie8 & {
         max-width: @ie8-max-width;

--- a/less/src/page-level-progress.less
+++ b/less/src/page-level-progress.less
@@ -111,3 +111,19 @@
         }
     }
 }
+
+// Page, Article, Block and Component PLP
+// ======================================
+.page,
+.article,
+.block,
+.component {
+    .page-level-progress-completion-indicator {
+        background-color: @navigation-progress-background-color;
+        border-color: @navigation-progress-border-color;
+    }
+
+    .page-level-progress-completion-inner-indicator {
+        background-color: @navigation-progress-color;
+    }
+}

--- a/less/src/page-level-progress.less
+++ b/less/src/page-level-progress.less
@@ -13,8 +13,11 @@
         }
 
         .pagelevelprogress-indicator-inner {
-            background-color: @navigation-progress-color-hover;
             border-color: @navigation-progress-background-color-hover;
+        }
+
+        .pagelevelprogress-indicator-bar {
+            background-color: @navigation-progress-color-hover;
         }
 
         .page-level-progress-plus-icon {
@@ -30,8 +33,12 @@
     }
 
     .pagelevelprogress-indicator-inner {
-        left: 0;
         border: 1px solid @navigation-progress-background-color;
+
+    }
+
+    .pagelevelprogress-indicator-bar {
+        left: 0;
         background-color: @navigation-progress-color;
         transition: all 0.3s ease-in;
         .transition-all-colors;
@@ -76,9 +83,13 @@
             background-color: @drawer-item-color;
             border-color: @drawer-progress-color;
         }
+
         .pagelevelprogress-indicator-inner {
-            background-color: @drawer-progress-color;
             border-color: @drawer-item-color;
+        }
+
+        .pagelevelprogress-indicator-bar {
+            background-color: @drawer-progress-color;
         }
 
         .no-touch &:hover {
@@ -89,9 +100,13 @@
                 background-color: @drawer-item-color-hover;
                 border-color: @drawer-progress-color-hover;
             }
+
             .pagelevelprogress-indicator-inner {
-                background-color: @drawer-progress-color-hover;
                 border-color: @drawer-item-color-hover;
+            }
+
+            .pagelevelprogress-indicator-bar {
+                background-color: @drawer-progress-color-hover;
             }
 
         }
@@ -106,14 +121,18 @@
 // =================
 .menu-header,
 .page-header {
+
     .pagelevelprogress-indicator {
         background-color: @background-color-inverted;
         border-color: @navigation-progress-background-color;
     }
 
     .pagelevelprogress-indicator-inner {
-        background-color: @navigation-progress-background-color;
         border-color: @background-color-inverted;
+    }
+
+    .pagelevelprogress-indicator-bar {
+        background-color: @navigation-progress-background-color;
     }
 }
 
@@ -123,29 +142,17 @@
 .article,
 .block,
 .component {
+
     .pagelevelprogress-indicator {
         background-color: @navigation-progress-background-color;
         border-color: @navigation-progress-border-color;
     }
 
     .pagelevelprogress-indicator-inner {
-        background-color: @navigation-progress-color;
         border-color: @navigation-progress-background-color;
     }
-}
 
-// Page, Article, Block and Component PLP
-// ======================================
-.page,
-.article,
-.block,
-.component {
-    .page-level-progress-completion-indicator {
-        background-color: @navigation-progress-background-color;
-        border-color: @navigation-progress-border-color;
-    }
-
-    .page-level-progress-completion-inner-indicator {
+    .pagelevelprogress-indicator-bar {
         background-color: @navigation-progress-color;
     }
 }

--- a/less/src/page-level-progress.less
+++ b/less/src/page-level-progress.less
@@ -73,12 +73,12 @@
 
         .pagelevelprogress-indicator {
             width: 15%;
-            background-color: @drawer-progress-border-color;
+            background-color: @drawer-item-color;
             border-color: @drawer-progress-color;
         }
         .pagelevelprogress-indicator-inner {
             background-color: @drawer-progress-color;
-            border-color: @drawer-progress-border-color;
+            border-color: @drawer-item-color;
         }
 
         .no-touch &:hover {
@@ -86,12 +86,12 @@
             color: @drawer-item-text-color-hover;
 
             .pagelevelprogress-indicator {
-                background-color: @drawer-item-color;
+                background-color: @drawer-item-color-hover;
                 border-color: @drawer-progress-color-hover;
             }
             .pagelevelprogress-indicator-inner {
                 background-color: @drawer-progress-color-hover;
-                border-color: @drawer-item-color;
+                border-color: @drawer-item-color-hover;
             }
 
         }

--- a/less/src/page-level-progress.less
+++ b/less/src/page-level-progress.less
@@ -1,9 +1,14 @@
+// General
+// =======
+.pagelevelprogress-indicator-bar {
+    transition: width 0.3s ease-in;
+}
+
 // Navigation PLP
 // ==============
 
-.page-level-progress-navigation {
-    padding:  @navigation-padding!important; // Override defaults in extension
-    margin: 0;
+.pagelevelprogress-navigation.base {
+    padding: @navigation-padding;
 
     .no-touch &:hover {
 
@@ -26,10 +31,10 @@
     }
 
     .pagelevelprogress-indicator {
+        transition: all 0.3s ease-in;
         background-color: @navigation-progress-background-color;
         border: 2px solid @navigation-progress-border-color;
         border-radius: 50px;
-        .transition-all-colors;
     }
 
     .pagelevelprogress-indicator-inner {
@@ -40,8 +45,7 @@
     .pagelevelprogress-indicator-bar {
         left: 0;
         background-color: @navigation-progress-color;
-        transition: all 0.3s ease-in;
-        .transition-all-colors;
+
 
         .dir-rtl & {
             right: 0;
@@ -50,24 +54,19 @@
     }
 }
 
-.page-level-progress-plus-icon {
-    right: 9px;
-}
-
 // Drawer PLP
 // ==========
 
 .drawer {
-    .page-level-progress-item-title {
-    	background-color: @drawer-item-color;
-    	color: @drawer-item-text-color;
-        .transition-all-colors;
+    .pagelevelprogress-item-title {
+        background-color: @drawer-item-color;
+        color: @drawer-item-text-color;
 
-    	&.drawer-item-open.disabled {
-    		background-color: @drawer-item-color-disabled;
-    		color: @drawer-item-text-color-disabled;
-    		font-size: @button-text-font-size;
-	        font-weight: @font-weight-light;
+        &.drawer-item-open.disabled {
+            background-color: @drawer-item-color-disabled;
+            color: @drawer-item-text-color-disabled;
+            font-size: @button-text-font-size;
+            font-weight: @font-weight-light;
 
             .no-touch &:hover {
                 background-color: @drawer-item-color-disabled;
@@ -76,7 +75,7 @@
                     background-color: transparent;
                 }
             }
-    	}
+        }
 
         .pagelevelprogress-indicator {
             width: 15%;
@@ -111,10 +110,6 @@
 
         }
     }
-}
-
-.page-level-progress-item-title-inner {
-	width:80%;
 }
 
 // Header indicators


### PR DESCRIPTION
[#2083](https://github.com/adaptlearning/adapt_framework/issues/2083)
* Made progress bars uniform in colour and size for dark and light backgrounds
* Added styling for new plp progress bars
* Added inner border to make bars easier to read
* Unified styling under new class name

### Test with
[plp#107](https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/pull/107)

List of outstanding PRs: https://github.com/adaptlearning/adapt_framework/issues/2206.