### PR TITLE
Add secure protocol to import

### DIFF
--- a/less/variables/fonts.less
+++ b/less/variables/fonts.less
@@ -1,7 +1,7 @@
 // Font setup
 // ==========
 
-@import url(//fonts.googleapis.com/css?family=Open+Sans:400,300,700);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:400,300,700);
 
 @font-family: 'Open Sans', Helvetica, Arial, sans-serif;
 


### PR DESCRIPTION
Resolves https://github.com/adaptlearning/adapt_framework/issues/2335.

@moloko, have obviously tested in IE11 over both HTTP and HTTPS but feel free to wade if there's an issue with the suggested change.