### PR TITLE
add default background-color to drawer-toolbar

### DIFF
--- a/less/core/drawer.less
+++ b/less/core/drawer.less
@@ -10,6 +10,7 @@
         width:100%;
         top:0;
         border-bottom: 1px solid @drawer-border-color;
+        background-color: @drawer-color;
     }
 
     .drawer-toolbar .icon {
@@ -21,7 +22,7 @@
             color: @drawer-icon-color-hover;
         }
     }
-    
+
     .drawer-holder {
         padding-top: ((@navigation-padding * 2) + @icon-size + 1);
     }
@@ -39,18 +40,18 @@
         .drawer-item-title {
             .sub-title;
         }
-        
+
         .drawer-item-description {
         	font-size: @body-text-font-size;
         	line-height: @body-text-line-height;
         }
-        
+
         .drawer-item-open {
             border-bottom: 1px solid @drawer-item-color;
             color: @drawer-item-text-color;
             text-decoration: none;
             width: 100%;
-            
+
             .no-touch &:hover {
                 background-color: @drawer-item-color-hover;
                 color: @drawer-item-text-color-hover;
@@ -62,7 +63,7 @@
         padding: @drawer-item-padding-top @drawer-item-padding-right @drawer-item-padding-bottom @drawer-item-padding-left;
         .transition-background-color;
 
-        //stops rollover of drawar items on touch devices    
+        //stops rollover of drawar items on touch devices
         .no-touch &:hover {
              background-color: @drawer-color;
        }


### PR DESCRIPTION
This is related to [framework issue #2498](https://github.com/adaptlearning/adapt_framework/issues/2498). 

Currently the drawer-toolbar has a transparent background. This PR assigns the @drawer-color to it background. This solid background i necessary to allow items to scroll behind it unseen.