### PR TITLE
v5: add background-color to drawer__toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,86 +1,105 @@
-# adapt-contrib-vanilla  
+# adapt-contrib-vanilla
 
-**Vanilla** is a *theme* bundled with the [Adapt framework](https://github.com/adaptlearning/adapt_framework).  
+**Vanilla** is a *theme* bundled with the [Adapt framework](https://github.com/adaptlearning/adapt_framework).
 
-<img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/vanilla01.jpg" alt="sample colors from the vanilla theme">  
+<img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/vanilla01.jpg" alt="sample colors from the vanilla theme">
 
-It provides specific values to styles, including colors, padding, margins, and assets such as fonts and background images. [Visit the **Vanilla** wiki](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki) for more information about its functionality and for explanations of key properties. 
+It provides specific values to styles, including colors, padding, margins, and assets such as fonts and background images. [Visit the **Vanilla** wiki](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki) for more information about its functionality and for explanations of key properties.
 
 ## Installation
 
 As Adapt's *[core theme](https://github.com/adaptlearning/adapt_framework/wiki/Core-Plug-ins-in-the-Adapt-Learning-Framework#theme),* **Vanilla** is included with the [installation of the Adapt framework](https://github.com/adaptlearning/adapt_framework/wiki/Manual-installation-of-the-Adapt-framework#installation) and the [installation of the Adapt authoring tool](https://github.com/adaptlearning/adapt_authoring/wiki/Installing-Adapt-Origin).
 
 * If **Vanilla** has been uninstalled from the Adapt framework, it may be reinstalled.
-With the [Adapt CLI](https://github.com/adaptlearning/adapt-cli) installed, run the following from the command line:  
+With the [Adapt CLI](https://github.com/adaptlearning/adapt-cli) installed, run the following from the command line:
 `adapt install adapt-contrib-vanilla`
 
-    Alternatively, this component can also be installed by adding the following line of code to the *adapt.json* file:  
-    `"adapt-contrib-vanilla": "*"`  
-    Then running the command:  
-    `adapt install`  
-    (This second method will reinstall all plug-ins listed in *adapt.json*.)  
+    Alternatively, this component can also be installed by adding the following line of code to the *adapt.json* file:
+    `"adapt-contrib-vanilla": "*"`
+    Then running the command:
+    `adapt install`
+    (This second method will reinstall all plug-ins listed in *adapt.json*.)
 
-* If **Vanilla** has been uninstalled from the Adapt authoring tool, it may be reinstalled using the [Plug-in Manager](https://github.com/adaptlearning/adapt_authoring/wiki/Plugin-Manager).  
+* If **Vanilla** has been uninstalled from the Adapt authoring tool, it may be reinstalled using the [Plug-in Manager](https://github.com/adaptlearning/adapt_authoring/wiki/Plugin-Manager).
 
 ## Uninstallation
 
-The Adapt framework does not allow the installation of more than one theme at a time. In order to replace **Vanilla** it must be uninstalled. With the root of your framework installation as your current working directory, run the following command:  
-`adapt uninstall adapt-contrib-vanilla`  
+The Adapt framework does not allow the installation of more than one theme at a time. In order to replace **Vanilla** it must be uninstalled. With the root of your framework installation as your current working directory, run the following command:
+`adapt uninstall adapt-contrib-vanilla`
 
 ## Settings overview
 
-Unlike most Adapt plug-ins, the **Vanilla** theme has no attributes that are required to be configured in the course JSON files. There is, however, an option to alter the background color of blocks as desired. Configure the attributes highlighted below in *blocks.json*. These attributes are properly formatted as JSON in [*example.json*](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/master/example.json).
+Unlike most Adapt plug-ins, the **Vanilla** theme has no attributes that are required to be configured in the course JSON files. There is, however, additional functionality available to apply background images and supporting styles for pages, articles and blocks as desired. These attributes are properly formatted as JSON in [*example.json*](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/master/example.json) and available as configurable attributes in the Adapt authoring tool.
+
+The **Vanilla** theme also exposes [*colour variables*](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/master/less/_defaults/colors.less) in the Adapt authoring tool for theme editing. This feature allows you to apply and save 'preset' theme styles.
+
+**\_vanilla** (object): The following attributes configure the defaults for **Vanilla**. These include **\_backgroundImage**, **\_backgroundStyles** and **\_minimumHeights**. Global attributes are available at page, article and block level.
+
+#### Global background image
+>**\_backgroundImage** (object): The backgroundImage object that contains values for **\_large**, **\_medium** and **\_small**.
+
+>>**\_large** (string): File name (including path) of the image used with large device width. Path should be relative to the *src* folder (e.g., *course/en/images/origami-menu-one.jpg*).
+
+>>**\_medium** (string): File name (including path) of the image used with medium device width. Path should be relative to the *src* folder (e.g., *course/en/images/origami-menu-one.jpg*).
+
+>>**\_small** (string): File name (including path) of the image used with small device width. Path should be relative to the *src* folder (e.g., *course/en/images/origami-menu-one.jpg*).
+
+#### Global background image styles
+>**_backgroundStyles** (object): Additional attributes available to customise how background images display. The backgroundStyles object contains values for **\_backgroundRepeat**, **\_backgroundSize** and **\_backgroundPosition**.
+
+>>**\_backgroundRepeat** (string): This attribute defines how the background image repeats. Properties include **repeat**, **repeat-x**, **repeat-y** and **no-repeat**.
+Repeat-x: The background image is repeated only horizontally. Repeat-y: The background image is repeated only vertically.
+
+>>**\_backgroundSize** (string): This attribute defines the size the background image display. Properties include **auto**, **cover** and **contain**.
+Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible.
+
+#### Global minimum heights
+>**_minimumHeights** (object): The minimum heights attribute group specifies the minimum height of the image container at different device widths (`_large`, `_medium`, and `_small`).
+
+>>**\_large** (number): The minimum height should only be used in instances where the image container height needs to be greater than the content e.g. to prevent a background image being cropped.
+
+>>**\_medium** (number): The minimum height should only be used in instances where the image container height needs to be greater than the content e.g. to prevent a background image being cropped.
+
+>>**\_small** (number): The minimum height should only be used in instances where the image container height needs to be greater than the content e.g. to prevent a background image being cropped.
+
+#### **contentObject.json**
+>**\_pageHeader** (object): The backgroundImage object that contains values for **\_large**, **\_medium** and **\_small**.
+
+>>**\_large** (string): File name (including path) of the image used with large device width. Path should be relative to the *src* folder (e.g., *course/en/images/origami-menu-one.jpg*).
+
+>>**\_medium** (string): File name (including path) of the image used with medium device width. Path should be relative to the *src* folder (e.g., *course/en/images/origami-menu-one.jpg*).
+
+>>**\_small** (string): File name (including path) of the image used with small device width. Path should be relative to the *src* folder (e.g., *course/en/images/origami-menu-one.jpg*).
 
 #### **blocks.json**
-**_theme** (object): The theme attributes group contains attributes that override those set in **Vanilla**. These include **_backgroundColor**, **_minimumHeights**, and **_isDividerBlock**.
+>**_isDividerBlock** (boolean): - Determines whether the CSS class `is-divider-block` will be applied. Acceptable values are `true` and `false`.
 
->**_backgroundColor** (string): This value is the name of a color variable that has been defined in  *less/colors.less*. Omit the initial `@` that is a part of the variable declaration. For example, an acceptable value is `"background-color-inverted"`.  
+Visit the [**Vanilla** wiki](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki) for more information about how to use and manipulate the theme.
 
->**_minimumHeights** (object): The minimum heights attribute group specifies the minimum height of the block at different device widths (`_large`, `_medium`, and `_small`).   
-
->>**_large** (number): This value specifies the CSS minimum height when `Adapt.device.screenSize'` evaluates to `"_large"`.  
-        
->>**_medium** (number): This value specifies the CSS minimum height when `Adapt.device.screenSize'` evaluates to `"_medium"`.   
-        
->>**_small** (number): This value specifies the CSS minimum height when `Adapt.device.screenSize'` evaluates to `"_small"`.   
- 
->**_isDividerBlock** (boolean): - Determines whether the CSS class `divider-block` *(less/src/theme-extras.less)* will be applied. Acceptable values are `true` and `false`.
-
-Visit the [**Vanilla** wiki](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki) for more information about how to use and manipulate the theme.  
-
-## Structure  
+## Structure
 
 | Folder/File         | Description  |
 | :-------------      |:-------------|
-| 📄 theme.json        | Pixel values for `screenSize`(`small`, `medium`, and `large`)|
-| 📄 selection.json    | File used for selecting icons at [IcoMoon.io](https://icomoon.io/) that are packaged in fonts/vanilla.* |
-| 📁 assets            | Location of theme assets (for example: images, loading gif, etc.)|
-| 📁 fonts             | Location of any theme font files |
-| 📁 js                | JavaScript files on which the theme depends      |
+| 📁 js                | JavaScript files on which the theme depends |
 | 📁 less              | Location of any [LESS](http://lesscss.org/) based CSS files |
-| 📄 less/generic.less | Variables that are not covered by those defined in colors.less, fonts.less, and paddings.less   |
-| 📁 less/src          | Location of LESS files for various Adapt elements |
-| 📄 less/src/theme-extras.less| Classes used for bespoke styling |
-| 📁 templates         | Location of overridden HTML (.hbs) templates |
-| 📁 templates/partials| Location of overridden HTML (.hbs) templates required by other templates, specifically buttons.hbs, component.hbs, and state.hbs |  
+| 📁 less/_defaults          | Location of configuration LESS files |
+| 📄 less/_defaults/colors.less | Location of global colour variables   |
+| 📁 less/core          | Location of Adapt Framework LESS file styles |
+| 📁 less/plugins          | Location of Adapt plugin LESS file styles |
+| 📁 less/project          | Location of additional LESS file styles |
 
 ## Templates
 
-**Vanilla** supports customisation for the rendering of various Adapt elements through the use of [Handlebars](http://handlebarsjs.com/) templates.  The file name of the template indicates the element it affects. Among the available templates are:
-* article.hbs
-* block.hbs
-* loading.hbs 
-* navigation.hbs
-* page.hbs
+**Vanilla** supports customisation for the rendering of various Adapt elements through the use of [Handlebars](http://handlebarsjs.com/) templates. The file name of the template indicates the element it affects.
 
 ## Limitations
- 
-No known limitations.  
+
+No known limitations.
 
 ----------------------------
-**Version number:**  4.1   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>  
-**Framework versions:**  4+     
-**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-vanilla/graphs/contributors)    
-**Accessibility support:** WAI AA   
-**RTL support:** yes  
-**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, IE Mobile 11, Safari 10+11 for macOS+iOS, Opera  
+**Version number:**  5.0.0  <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>  
+**Framework versions:**  5+  
+**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-vanilla/graphs/contributors)  
+**Accessibility support:** WAI AA  
+**RTL support:** Yes  
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 12+13 for macOS/iOS/iPadOS, Opera  

--- a/bower.json
+++ b/bower.json
@@ -1,18 +1,18 @@
 {
   "name": "adapt-contrib-vanilla",
-  "version": "4.1.0",
-  "framework": ">=4",
+  "version": "5.0.0",
+  "framework": ">=5",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-vanilla",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",
-  "displayName": "Vanilla",
   "theme": "vanilla",
+  "displayName": "Vanilla",
   "description": "A core bundled theme",
   "main": "js/theme.js",
   "keywords": [
     "adapt-plugin",
     "adapt-theme"
   ],
-  "license": "GPLv3",
+  "license": "GPL-3.0",
   "ignore": [
     "**/.*",
     "node_modules",
@@ -20,5 +20,5 @@
     "test",
     "tests"
   ],
-  "_targetAttribute": "_vanilla"
+  "targetAttribute": "_vanilla"
 }

--- a/example.json
+++ b/example.json
@@ -1,18 +1,84 @@
-// THEME EXAMPLE JSON - The below config is optional to apply additional theme styles.
-// ==================
+Background images, styles, and minimum heights
 
-// All conifigurable LESS is set in theme-extras.less
-
-// Block Config
-// ============
-
-"_theme": {
-    // Background Color - set background color based on color variables defined in colors.less
-    "_backgroundColor": "background-color-inverted",
-    // Minimum Heights - set minimum heights on blocks at different device widths
-    "_minimumHeights": {
-        "_large": 500,
-        "_medium": 500,
-        "_small": 300
+    // contentObjects.json
+    "_vanilla": {
+        "_backgroundImage": {
+            "_large": "course/en/images/example.jpg",
+            "_medium": "course/en/images/example.jpg",
+            "_small": "course/en/images/example.jpg"
+        },
+        "_backgroundStyles": {
+            "_backgroundSize": "contain",
+            "_backgroundRepeat": "repeat",
+            "_backgroundPosition": "center center"
+        },
+        "_pageHeader": {
+            "_backgroundImage": {
+                "_large": "course/en/images/example.jpg",
+                "_medium": "course/en/images/example.jpg",
+                "_small": "course/en/images/example.jpg"
+            },
+            "_backgroundStyles": {
+                "_backgroundSize": "contain",
+                "_backgroundRepeat": "repeat",
+                "_backgroundPosition": "center center"
+            },
+            "_minimumHeights": {
+                "_large": 600,
+                "_medium": 400,
+                "_small": 200
+            }
+        }
     }
-}
+
+    // articles.json
+    "_vanilla": {
+        "_backgroundImage": {
+            "_large": "course/en/images/example.jpg",
+            "_medium": "course/en/images/example.jpg",
+            "_small": "course/en/images/example.jpg"
+        },
+        "_backgroundStyles": {
+            "_backgroundSize": "contain",
+            "_backgroundRepeat": "repeat",
+            "_backgroundPosition": "center center"
+        }
+    }
+
+    // blocks.json
+    "_vanilla": {
+        "_backgroundImage": {
+            "_large": "course/en/images/example.jpg",
+            "_medium": "course/en/images/example.jpg",
+            "_small": "course/en/images/example.jpg"
+        },
+        "_backgroundStyles": {
+            "_backgroundSize": "contain",
+            "_backgroundRepeat": "repeat",
+            "_backgroundPosition": "center center"
+        },
+        "_minimumHeights": {
+            "_large": 600,
+            "_medium": 400,
+            "_small": 200
+        },
+        // Divider Block - adds class to `.block` element
+        "_isDividerBlock": false
+    }
+
+On screen animation classes
+
+    "_onScreen": {
+        "_isEnabled": true,
+        "_comment": "Supported classes = 'fade-in' | 'fade-in-left' | 'fade-in-right' | 'fade-in-top' | 'fade-in-bottom'. Additional classes can be used but they must be predefined in one of the Less files",
+        "_classes": "fade-in-bottom",
+        "_percentInviewVertical": 50
+    }
+
+Block classes
+
+    "_comment": "Aligns child components centrally on the vertical axis",
+    "_classes": "align-vert-center"
+
+    "_comment": "Background color mixin. 'block-color' class is set up to be a common class that can be used for style generic overrides. The second class must match a predefined variable in the theme or added in Project Settings > Custom CSS/Less code.",
+    "_classes": "block-color black"

--- a/js/themeBlockView.js
+++ b/js/themeBlockView.js
@@ -5,7 +5,9 @@ define([
 
   var ThemeBlockView = ThemeView.extend({
 
-    className: function() {},
+    className: function() {
+      return this.model.get("_isDividerBlock") ? "is-divider-block" : "";
+    },
 
     setCustomStyles: function() {},
 

--- a/js/themePageView.js
+++ b/js/themePageView.js
@@ -13,15 +13,17 @@ define([
 
     processHeader: function() {
       var header = this.model.get('_pageHeader');
-      var $header = this.$('.page__header');
 
       if (!header) return;
 
-      this.setElementBackground(header, $header);
-      this.setElementMinHeight(header, $header);
+      var $header = this.$('.page__header');
+
+      this.setHeaderBackgroundImage(header, $header);
+      this.setHeaderBackgroundStyles(header, $header);
+      this.setHeaderMinimumHeight(header, $header);
     },
 
-    setElementBackground: function(config, $element) {
+    setHeaderBackgroundImage: function(config, $header) {
       var backgroundImages = config._backgroundImage;
 
       if (!backgroundImages) return;
@@ -39,36 +41,56 @@ define([
           backgroundImage = backgroundImages._small;
       }
 
-      if (!backgroundImage) return;
-
-      $element
-        .addClass("has-bg-image")
-        .css("background-image", "url(" + backgroundImage + ")");
+      if (backgroundImage) {
+        $header
+          .addClass("has-bg-image")
+          .css("background-image", "url(" + backgroundImage + ")");
+      } else {
+        $header
+          .removeClass("has-bg-image")
+          .css("background-image", "");
+      }
     },
 
-    setElementMinHeight: function(config, $element) {
-      var minHeights = config._minHeight;
+    setHeaderBackgroundStyles: function (config, $header) {
+      var styles = config._backgroundStyles;
 
-      if (!minHeights) return;
+      if (!styles) return;
 
-      var minHeight;
+      $header.css({
+        'background-repeat': styles._backgroundRepeat,
+        'background-size': styles._backgroundSize,
+        'background-position': styles._backgroundPosition
+      });
+    },
+
+    setHeaderMinimumHeight: function(config, $header) {
+      var minimumHeights = config._minimumHeights;
+
+      if (!minimumHeights) return;
+
+      var minimumHeight;
 
       switch (Adapt.device.screenSize) {
         case "large":
-          minHeight = minHeights._large;
+          minimumHeight = minimumHeights._large;
           break;
         case "medium":
-          minHeight = minHeights._medium;
+          minimumHeight = minimumHeights._medium;
           break;
         default:
-          minHeight = minHeights._small;
+          minimumHeight = minimumHeights._small;
       }
 
-      if (!minHeight) return;
-
-      $element
-        .addClass('has-min-height')
-        .css("min-height", minHeight + "px");
+      if (minimumHeight) {
+        $header
+          .addClass("has-min-height")
+          .css("min-height", minimumHeight + "px");
+      } else {
+        $header
+          .removeClass("has-min-height")
+          .css("min-height", "");
+      }
     },
 
     onRemove: function() {}

--- a/js/themeView.js
+++ b/js/themeView.js
@@ -10,7 +10,7 @@ define([
       this.setStyles();
 
       this.listenTo(Adapt, {
-        "device:resize": this.onDeviceResize,
+        "device:changed": this.onDeviceResize,
         "remove": this.remove
       });
     },
@@ -28,7 +28,8 @@ define([
     setStyles: function() {
       this.setClasses();
       this.setBackgroundImage();
-      this.setMinHeight();
+      this.setBackgroundStyles();
+      this.setMinimumHeight();
       this.setCustomStyles();
     },
 
@@ -54,36 +55,56 @@ define([
           backgroundImage = backgroundImages._small;
       }
 
-      if (!backgroundImage) return;
-
-      this.$el
-        .addClass("has-bg-image")
-        .css("background-image", "url(" + backgroundImage + ")");
+      if (backgroundImage) {
+        this.$el
+          .addClass("has-bg-image")
+          .css("background-image", "url(" + backgroundImage + ")");
+      } else {
+        this.$el
+          .removeClass("has-bg-image")
+          .css("background-image", "");
+      }
     },
 
-    setMinHeight: function() {
-      var minHeights = this.model.get("_minHeight");
+    setBackgroundStyles: function () {
+      var styles = this.model.get("_backgroundStyles");
 
-      if (!minHeights) return;
+      if (!styles) return;
 
-      var minHeight;
+      this.$el.css({
+        'background-repeat': styles._backgroundRepeat,
+        'background-size': styles._backgroundSize,
+        'background-position': styles._backgroundPosition
+      });
+    },
+
+    setMinimumHeight: function() {
+      var minimumHeights = this.model.get("_minimumHeights");
+
+      if (!minimumHeights) return;
+
+      var minimumHeight;
 
       switch (Adapt.device.screenSize) {
         case "large":
-          minHeight = minHeights._large;
+          minimumHeight = minimumHeights._large;
           break;
         case "medium":
-          minHeight = minHeights._medium;
+          minimumHeight = minimumHeights._medium;
           break;
         default:
-          minHeight = minHeights._small;
+          minimumHeight = minimumHeights._small;
       }
 
-      if (!minHeight) return;
-
-      this.$el
-        .addClass('has-min-height')
-        .css("min-height", minHeight + "px");
+      if (minimumHeight) {
+        this.$el
+          .addClass("has-min-height")
+          .css("min-height", minimumHeight + "px");
+      } else {
+        this.$el
+          .removeClass("has-min-height")
+          .css("min-height", "");
+      }
     },
 
     setCustomStyles: function() {},

--- a/less/_defaults/_animations.less
+++ b/less/_defaults/_animations.less
@@ -2,6 +2,7 @@
 // Variables
 // --------------------------------------------------
 @duration: 0.2s;
+@progress-duration: 0.5s;
 
 @animation-duration: 2000ms;
 @animation-easing: cubic-bezier(.23,1,.32,1);
@@ -10,8 +11,12 @@
 // --------------------------------------------------
 // Basic image zoom on hover animation
 // Apply to image container
+//
+// .img-zoom();
+// .img-zoom(@duration: .5s;);
+// .img-zoom(1.25; .1s; ease-out;);
 // --------------------------------------------------
-.img-zoom(@scale: 1.2; @duration: .25s; @easing: ease-in-out;) {
+.img-zoom(@scale: 1.1; @duration: .75s; @easing: ease-in-out;) {
   overflow: hidden;
 
   img {
@@ -114,10 +119,9 @@
 // --------------------------------------------------
 
 // --------------------------------------------------
-//
+// Scale Pulse Animation
 // --------------------------------------------------
 .effect-scalePulse() {
-
   .keyframes(scalePulse; {
     0% { transform: none; }
     50% { transform: scale( 1.2, 1.2 ); }
@@ -125,9 +129,12 @@
   });
 
   .animation(scalePulse 0.5s 0s 1 normal ease-in-out none);
-
+  // name, duration, delay, iteration count, direction, timing-function, fill mode
 }
 // --------------------------------------------------
+
+
+
 
 
 // --------------------------------------------------

--- a/less/_defaults/_colors.less
+++ b/less/_defaults/_colors.less
@@ -5,26 +5,29 @@
 @blueDark: #263944;
 @grey: #9096A0;
 @greyDark: #4D4D4D;
+
+// These variables are used to change the colour of text
+// Primary use is for altering the text colour over a background image
+// See ../project/theme-extras.less for block mixin
+// --------------------------------------------------
+@transparent-light: transparent;
+@transparent-dark: transparent;
 // --------------------------------------------------
 
 // --------------------------------------------------
-// Headings
-// --------------------------------------------------
-@heading-color: @blue;
-@heading-color-inverted: @white;
-// --------------------------------------------------
-
-// --------------------------------------------------
-// Body and link colour
+// Body, link, and heading colour
 // --------------------------------------------------
 @font-color: @greyDark;
 @font-color-inverted: @white;
 
-@link: @greyDark;
-@link-inverted: @white;
+@link: @font-color;
+@link-inverted: @font-color-inverted;
 
 @link-hover: @link;
-@link-hover-inverted: @link-inverted;
+@link-inverted-hover: @link-inverted;
+
+@heading-color: @blue;
+@heading-color-inverted: @white;
 // --------------------------------------------------
 
 // --------------------------------------------------
@@ -38,6 +41,13 @@
 
 @item-color-selected: darken(@item-color, 20%);
 @item-color-inverted-selected: @item-color-inverted;
+// --------------------------------------------------
+
+// --------------------------------------------------
+// Visited - presentation components
+// --------------------------------------------------
+@visited: #727272;
+@visited-inverted: @white;
 // --------------------------------------------------
 
 // --------------------------------------------------
@@ -55,13 +65,6 @@
 // --------------------------------------------------
 @disabled: #DDDDDD;
 @disabled-inverted: @black;
-// --------------------------------------------------
-
-// --------------------------------------------------
-// Visited - presentation components
-// --------------------------------------------------
-@visited: #727272;
-@visited-inverted: @white;
 // --------------------------------------------------
 
 // --------------------------------------------------
@@ -85,8 +88,8 @@
 // --------------------------------------------------
 // Navigation
 // --------------------------------------------------
-@nav: @grey;
-@nav-inverted: @white;
+@nav: @white;
+@nav-inverted: @grey;
 
 @nav-icon: @nav-inverted;
 @nav-icon-inverted: @nav;
@@ -110,10 +113,8 @@
 @notify-inverted: @white;
 
 @notify-link: @notify-inverted;
-@notify-link-inverted: @notify;
 
 @notify-link-hover: @notify-link;
-@notify-link-inverted-hover: @notify-link-inverted;
 
 @notify-btn: @btn-color-inverted;
 @notify-btn-inverted: @btn-color;
@@ -121,8 +122,8 @@
 @notify-btn-hover: darken(@notify-btn, 10%);
 @notify-btn-inverted-hover: @notify-btn-inverted;
 
-@notify-icon: @btn-color;
-@notify-icon-inverted: @btn-color-inverted;
+@notify-icon: @notify;
+@notify-icon-inverted: @notify-inverted;
 
 @notify-icon-hover: darken(@notify-icon, 10%);
 @notify-icon-inverted-hover: @notify-icon-inverted;
@@ -135,10 +136,8 @@
 @drawer-inverted: @white;
 
 @drawer-link: @drawer-inverted;
-@drawer-link-inverted: @drawer;
 
 @drawer-link-hover: @drawer-link;
-@drawer-link-inverted-hover: @drawer-link-inverted;
 
 @drawer-icon: @drawer;
 @drawer-icon-inverted: @drawer-inverted;

--- a/less/_defaults/_font-config.less
+++ b/less/_defaults/_font-config.less
@@ -41,22 +41,22 @@
 // --------------------------------------------------
 // Globals
 // --------------------------------------------------
-@body-size: 1em;
+@body-size: 1rem;
 @body-weight: @font-weight-regular;
 
-@instruction-size: 1em;
+@instruction-size: 1rem;
 @instruction-family: @body-family;
 @instruction-weight: @font-weight-regular;
 @instruction-line-height: @body-line-height;
 
-@btn-size: 1em;
+@btn-size: 1rem;
 @btn-weight: @font-weight-regular;
 
-@icon-size: 1.5em;
+@icon-size: 1.5rem;
 @icon-weight: @font-weight-regular;
 @icon-line-height: 1;
 
-@link-size: 1em;
+@link-size: 1rem;
 @link-family: @body-family;
 @link-weight: @font-weight-regular;
 @link-line-height: @body-line-height;
@@ -65,22 +65,22 @@
 // --------------------------------------------------
 // Menu header
 // --------------------------------------------------
-@menu-title-size: 3em;
+@menu-title-size: 3rem;
 @menu-title-family: @title-family;
 @menu-title-weight: @font-weight-regular;
 @menu-title-line-height: @title-line-height;
 
-@menu-subtitle-size: 2em;
+@menu-subtitle-size: 2rem;
 @menu-subtitle-family: @title-family;
 @menu-subtitle-weight: @font-weight-light;
 @menu-subtitle-line-height: @title-line-height;
 
-@menu-body-size: 1.25em;
+@menu-body-size: 1.25rem;
 @menu-body-family: @body-family;
 @menu-body-weight: @font-weight-regular;
 @menu-body-line-height: @body-line-height;
 
-@menu-instruction-size: 1.25em;
+@menu-instruction-size: 1.25rem;
 @menu-instruction-family: @body-family;
 @menu-instruction-weight: @font-weight-regular;
 @menu-instruction-line-height: @body-line-height;
@@ -89,12 +89,12 @@
 // --------------------------------------------------
 // Menu item
 // --------------------------------------------------
-@menu-item-title-size: 1.25em;
+@menu-item-title-size: 1.25rem;
 @menu-item-title-family: @title-family;
-@menu-item-title-weight: @font-weight-bold;
+@menu-item-title-weight: @font-weight-regular;
 @menu-item-title-line-height: @title-line-height;
 
-@menu-item-body-size: 1em;
+@menu-item-body-size: 1rem;
 @menu-item-body-family: @body-family;
 @menu-item-body-weight: @font-weight-light;
 @menu-item-body-line-height: @body-line-height;
@@ -103,22 +103,22 @@
 // --------------------------------------------------
 // Page header
 // --------------------------------------------------
-@page-title-size: 3em;
+@page-title-size: 3rem;
 @page-title-family: @title-family;
-@page-title-weight: @font-weight-light;
+@page-title-weight: @font-weight-regular;
 @page-title-line-height: @title-line-height;
 
-@page-subtitle-size: 2em;
+@page-subtitle-size: 2rem;
 @page-subtitle-family: @title-family;
 @page-subtitle-weight: @font-weight-light;
 @page-subtitle-line-height: @title-line-height;
 
-@page-body-size: 1.25em;
+@page-body-size: 1.25rem;
 @page-body-family: @body-family;
 @page-body-weight: @font-weight-regular;
 @page-body-line-height: @body-line-height;
 
-@page-instruction-size: 1.25em;
+@page-instruction-size: 1.25rem;
 @page-instruction-family: @body-family;
 @page-instruction-weight: @font-weight-regular;
 @page-instruction-line-height: @body-line-height;
@@ -127,27 +127,27 @@
 // --------------------------------------------------
 // Page
 // --------------------------------------------------
-@article-title-size: 2.5em;
+@article-title-size: 2.5rem;
 @article-title-family: @title-family;
 @article-title-weight: @font-weight-regular;
 @article-title-line-height: @title-line-height;
 
-@block-title-size: 2.5em;
+@block-title-size: 2.5rem;
 @block-title-family: @title-family;
 @block-title-weight: @font-weight-regular;
 @block-title-line-height: @title-line-height;
 
-@component-title-size: 2.5em;
+@component-title-size: 2.5rem;
 @component-title-family: @title-family;
 @component-title-weight: @font-weight-regular;
 @component-title-line-height: @title-line-height;
 
-@notify-title-size: 2.5em;
+@notify-title-size: 2.5rem;
 @notify-title-family: @title-family;
 @notify-title-weight: @font-weight-regular;
 @notify-title-line-height: @title-line-height;
 
-@item-title-size: 1.25em;
+@item-title-size: 1.25rem;
 @item-title-family: @title-family;
 @item-title-weight: @font-weight-regular;
 @item-title-line-height: @title-line-height;
@@ -155,12 +155,12 @@
 // --------------------------------------------------
 // Pull quote
 // --------------------------------------------------
-@pull-quote-title-size: 2.5em;
+@pull-quote-title-size: 2.5rem;
 @pull-quote-title-family: @title-family;
 @pull-quote-title-weight: @font-weight-light;
 @pull-quote-title-line-height: @title-line-height;
 
-@pull-quote-body-size: 2em;
+@pull-quote-body-size: 2rem;
 @pull-quote-body-family: @body-family;
 @pull-quote-body-weight: @font-weight-light;
 @pull-quote-body-line-height: @body-line-height;
@@ -169,17 +169,17 @@
 // --------------------------------------------------
 // Drawer
 // --------------------------------------------------
-@drawer-item-title-size: 1em;
+@drawer-item-title-size: 1rem;
 @drawer-item-title-family: @title-family;
 @drawer-item-title-weight: @font-weight-regular;
 @drawer-item-title-line-height: @title-line-height;
 
-@drawer-item-body-size: 0.875em;
+@drawer-item-body-size: 0.875rem;
 @drawer-item-body-family: @body-family;
 @drawer-item-body-weight: @font-weight-regular;
 @drawer-item-body-line-height: @body-line-height;
 
-@resources-filter-btn-size: 1em;
+@resources-filter-btn-size: 1rem;
 @resources-filter-btn-family: @btn-family;
 @resources-filter-btn-weight: @font-weight-regular;
 @resources-filter-btn-line-height: @body-line-height;

--- a/less/_defaults/_spacing-config.less
+++ b/less/_defaults/_spacing-config.less
@@ -1,28 +1,28 @@
 // --------------------------------------------------
 // Icon
 // --------------------------------------------------
-@icon-padding: 1em;
+@icon-padding: 1rem;
 // --------------------------------------------------
 
 // --------------------------------------------------
 // Item
 // --------------------------------------------------
-@item-margin: 0.5em;
-@item-padding: 1em;
+@item-margin: 0.5rem;
+@item-padding: 1rem;
 // --------------------------------------------------
 
 // --------------------------------------------------
 // Button
 // --------------------------------------------------
-@btn-margin: 1em;
-@btn-padding: 1em;
+@btn-margin: 1rem;
+@btn-padding: 1rem;
 // --------------------------------------------------
 
 // --------------------------------------------------
 // Menu header text margin
 // --------------------------------------------------
-@menu-title-margin: 1em;
-@menu-subtitle-margin: 1em;
+@menu-title-margin: 1rem;
+@menu-subtitle-margin: 1rem;
 @menu-body-margin: 0;
 @menu-instruction-margin: 0;
 // --------------------------------------------------
@@ -30,40 +30,47 @@
 // --------------------------------------------------
 // Menu item text margin
 // --------------------------------------------------
-@menu-item-image-margin: 1em;
-@menu-item-title-margin: 0.75em;
-@menu-item-body-margin: 1em;
-@menu-item-duration-margin: 1em;
-@menu-item-progress-margin: 1em;
+@menu-item-image-margin: 1rem;
+@menu-item-title-margin: 0.75rem;
+@menu-item-body-margin: 1rem;
+@menu-item-duration-margin: 1rem;
+@menu-item-progress-margin: 1rem;
 // --------------------------------------------------
 
 // --------------------------------------------------
 // Page header text margin
 // --------------------------------------------------
-@page-title-margin: 0.5em;
-@page-subtitle-margin: 1em;
-@page-body-margin: 1em;
-@page-instruction-margin: 1em;
+@page-title-margin: 0.5rem;
+@page-subtitle-margin: 1rem;
+@page-body-margin: 1rem;
+@page-instruction-margin: 1rem;
 // --------------------------------------------------
 
 // --------------------------------------------------
 // Page text margin
 // --------------------------------------------------
-@article-title-margin: 1em;
-@article-body-margin: 1em;
-@article-instruction-margin: 1em;
+@article-title-margin: 1rem;
+@article-body-margin: 1rem;
+@article-instruction-margin: 1rem;
 
-@block-title-margin: 1em;
-@block-body-margin: 1em;
-@block-instruction-margin: 1em;
+@block-title-margin: 1rem;
+@block-body-margin: 1rem;
+@block-instruction-margin: 1rem;
 
-@component-title-margin: 1em;
-@component-body-margin: 1em;
-@component-instruction-margin: 1em;
+@component-title-margin: 1rem;
+@component-body-margin: 1rem;
+@component-instruction-margin: 1rem;
 
-@notify-title-margin: 1em;
-@notify-body-margin: 1em;
+@notify-title-margin: 1rem;
+@notify-body-margin: 1rem;
 @notify-instruction-margin: 0;
 
-@item-title-margin: 1em;
+@item-title-margin: 1rem;
+// --------------------------------------------------
+
+// --------------------------------------------------
+// Drawer
+// --------------------------------------------------
+@drawer-title-margin: 0.25rem;
+@drawer-body-margin: 0;
 // --------------------------------------------------

--- a/less/_defaults/_spacing-containers.less
+++ b/less/_defaults/_spacing-containers.less
@@ -5,7 +5,7 @@
 @device-width-medium: unit(@adapt-device-medium, rem);
 @device-width-large: unit(@adapt-device-large, rem);
 
-@max-width: 87.5rem;
+@max-width: 90rem;
 // --------------------------------------------------
 
 // --------------------------------------------------
@@ -20,8 +20,8 @@
 @menu-padding-ver: 0;
 @menu-padding-hoz: 0;
 
-@menu-header-padding-ver: 2em;
-@menu-header-padding-hoz: 0.5em;
+@menu-header-padding-ver: 2rem;
+@menu-header-padding-hoz: 0.5rem;
 // --------------------------------------------------
 
 // --------------------------------------------------
@@ -30,29 +30,29 @@
 @page-padding-ver: 0;
 @page-padding-hoz: 0;
 
-@page-header-padding-ver: 2em;
-@page-header-padding-hoz: 0.5em;
+@page-header-padding-ver: 2rem;
+@page-header-padding-hoz: 0.5rem;
 // --------------------------------------------------
 
 // --------------------------------------------------
 // Article header padding
 // --------------------------------------------------
 @article-header-padding-ver: 0;
-@article-header-padding-hoz: 0.5em;
+@article-header-padding-hoz: 0.5rem;
 // --------------------------------------------------
 
 // --------------------------------------------------
 // Block padding
 // --------------------------------------------------
-@block-padding-ver: 4em;
-@block-padding-hoz: 0.5em;
+@block-padding-ver: 4rem;
+@block-padding-hoz: 0.5rem;
 // --------------------------------------------------
 
 // --------------------------------------------------
 // Notify padding
 // --------------------------------------------------
-@notify-padding-ver: 4em;
-@notify-padding-hoz: 0.5em;
+@notify-padding-ver: 4rem;
+@notify-padding-hoz: 0.5rem;
 // --------------------------------------------------
 
 // --------------------------------------------------

--- a/less/core/article.less
+++ b/less/core/article.less
@@ -1,8 +1,8 @@
 .article {
   &.has-bg-image {
-    background-position: center top;
     background-repeat: no-repeat;
     background-size: cover;
+    background-position: center top;
   }
 
   &__header-inner {

--- a/less/core/attribution.less
+++ b/less/core/attribution.less
@@ -1,0 +1,19 @@
+.has-attribution {
+  position: relative;
+}
+
+.component__attribution {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  padding: @item-padding;
+  background-color: fade(@background, 50%);
+  color: @background-inverted;
+  transform: translate3d(0,0,0);
+}
+
+// Override position: absolute; as it won't work with current GMCQ structure
+.gmcq__attribution {
+  position: relative;
+}

--- a/less/core/block.less
+++ b/less/core/block.less
@@ -1,8 +1,8 @@
 .block {
   &.has-bg-image {
-    background-position: center top;
     background-repeat: no-repeat;
     background-size: cover;
+    background-position: center top;
   }
 
   &__inner {
@@ -28,49 +28,4 @@
   &__instruction a {
     .link-text;
   }
-
-  // --------------------------------------------------
-  // Custom class added to block
-  // Aligns child components centrally on the vertical axis
-  // --------------------------------------------------
-  &.align-vert-center .component__container {
-    align-items: center;
-  }
-  // --------------------------------------------------
-
-  // --------------------------------------------------
-  // Background color mixin
-  // Add to block to enable
-  // e.g. 'block-color black'
-  // --------------------------------------------------
-  .block-bg-color-mixin(black, white);
-
-  .block-bg-color-mixin(@color, @color-inverted) {
-    &-color.@{color} {
-      background-color: @@color;
-      color: @@color-inverted;
-
-      .block,
-      .component {
-        &__title,
-        &__body a,
-        &__instruction a {
-          color: @@color-inverted;
-        }
-      }
-
-      .pagelevelprogress {
-        &__indicator {
-          border-color: @@color-inverted;
-        }
-        &__indicator-inner {
-          background-color: @@color;
-        }
-        &__indicator-bar {
-          background-color: @@color-inverted;
-        }
-      }
-    }
-  }
-  // --------------------------------------------------
 }

--- a/less/core/button.less
+++ b/less/core/button.less
@@ -28,4 +28,14 @@
     padding: @item-padding * 0.75;
     border-radius: 50%;
   }
+
+  .can-show-marking &__action.is-full-width,
+  .can-show-marking &__feedback.is-full-width {
+    margin-right: @icon-size + (@item-margin * 2) + ((@item-padding * 0.75) * 2);
+
+    .dir-rtl & {
+      margin-right: inherit;
+      margin-left: @icon-size + (@item-margin * 2) + ((@item-padding * 0.75) * 2);
+    }
+  }
 }

--- a/less/core/drawer.less
+++ b/less/core/drawer.less
@@ -3,6 +3,7 @@
 
   &__toolbar {
     border-bottom: 1px solid @drawer-item-hover;
+    background-color: @drawer;
   }
 
   // --------------------------------------------------

--- a/less/core/drawerItem.less
+++ b/less/core/drawerItem.less
@@ -18,7 +18,13 @@
     color: @disabled-inverted;
   }
 
+  &__item-btn.is-selected {
+    background-color: @drawer-item-selected;
+    color: @drawer-item-inverted-selected;
+  }
+
   &__item-title {
+    margin-bottom: @drawer-title-margin;
     .drawer-item-title;
     text-align: left;
 
@@ -28,6 +34,7 @@
   }
 
   &__item-body {
+    margin-bottom: @drawer-body-margin;
     .drawer-item-body;
     text-align: left;
 

--- a/less/core/loading.less
+++ b/less/core/loading.less
@@ -7,12 +7,10 @@
   &__inner,
   &__inner:before,
   &__inner:after {
-    width: 2em;
-    height: 2em;
+    width: 2rem;
+    height: 2rem;
     border-radius: 50%;
-    -webkit-animation-fill-mode: both;
     animation-fill-mode: both;
-    -webkit-animation: loading 1.25s infinite ease-in-out;
     animation: loading 1.25s infinite ease-in-out;
   }
 
@@ -22,8 +20,7 @@
     left: 0;
     right: 0;
     margin: auto;
-    text-indent: -9999em;
-    -webkit-animation-delay: -@loading-anim-delay;
+    text-indent: -9999rem;
     animation-delay: -@loading-anim-delay;
     .transform(translateZ(0));
   }
@@ -36,24 +33,12 @@
   }
 
   &__inner:before {
-    left: -3em;
-    -webkit-animation-delay: -@loading-anim-delay * 2;
+    left: -3rem;
     animation-delay: -@loading-anim-delay * 2;
   }
 
   &__inner:after {
-    left: 3em;
-  }
-}
-
-@-webkit-keyframes loading {
-  0%,
-  80%,
-  100% {
-    box-shadow: 0 2.5em 0 -1.3em;
-  }
-  40% {
-    box-shadow: 0 2.5em 0 0;
+    left: 3rem;
   }
 }
 
@@ -61,9 +46,9 @@
   0%,
   80%,
   100% {
-    box-shadow: 0 2.5em 0 -1.3em;
+    box-shadow: 0 2.5rem 0 -1.3rem;
   }
   40% {
-    box-shadow: 0 2.5em 0 0;
+    box-shadow: 0 2.5rem 0 0;
   }
 }

--- a/less/core/nav.less
+++ b/less/core/nav.less
@@ -15,8 +15,4 @@
       .transition(background-color @duration ease-in, color @duration ease-in;);
     }
   }
-
-  .hide-nav-back-btn &__back-btn {
-    .u-display-none;
-  }
 }

--- a/less/core/notify.less
+++ b/less/core/notify.less
@@ -65,7 +65,7 @@
   &__btn-icon {
     margin: @btn-margin / 2;
     padding: @btn-padding / 2;
-    background-color: transparent;
+    background-color: @notify-icon;
     color: @notify-icon-inverted;
     border-radius: 50%;
 
@@ -75,17 +75,6 @@
       .transition(background-color @duration ease-in, color @duration ease-in;);
     }
   }
-
-  // &__btn-icon {
-  //   background-color: @notify-icon;
-  //   color: @notify-icon-inverted;
-
-  //   .no-touch &:hover {
-  //     background-color: @notify-icon-hover;
-  //     color: @notify-icon-inverted-hover;
-  //     .transition(background-color @duration ease-in, color @duration ease-in;);
-  //   }
-  // }
 
   &__close-btn {
     position: absolute;

--- a/less/core/page.less
+++ b/less/core/page.less
@@ -2,10 +2,16 @@
   max-width: inherit;
   .l-container-padding(@page-padding-ver, @page-padding-hoz);
 
-  &__header.has-bg-image {
-    background-position: center top;
+  &.has-bg-image {
     background-repeat: no-repeat;
     background-size: cover;
+    background-position: center top;
+  }
+
+  &__header.has-bg-image {
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: center top;
   }
 
   &__header-inner {
@@ -15,6 +21,7 @@
   &__title {
     margin-bottom: @page-title-margin;
     .page-title;
+    color: @heading-color;
   }
 
   &__subtitle {

--- a/less/plugins/adapt-contrib-accordion/accordion.less
+++ b/less/plugins/adapt-contrib-accordion/accordion.less
@@ -10,6 +10,7 @@
     text-align: left;
     background-color: @item-color;
     color: @item-color-inverted;
+    border-radius: 5px;
 
     .no-touch &:not(.is-selected):hover {
       background-color: @item-color-hover;
@@ -47,12 +48,13 @@
   }
 
   &__item-content {
-    padding: @item-padding / 2;
+    padding: @item-padding;
     background-color: @item-color;
     color: @item-color-inverted;
+    border-radius: 5px;
   }
 
-  &__item-image-container {
+  &.has-img-zoom &__item-image-container {
     .img-zoom();
   }
 }

--- a/less/plugins/adapt-contrib-boxmenu/boxMenu.less
+++ b/less/plugins/adapt-contrib-boxmenu/boxMenu.less
@@ -1,10 +1,17 @@
 .boxmenu {
+  max-width: inherit;
   .l-container-padding(@menu-padding-ver, @menu-padding-hoz);
 
-  &__header.has-bg-image {
-    background-position: center top;
+  &.has-bg-image {
     background-repeat: no-repeat;
     background-size: cover;
+    background-position: center top;
+  }
+
+  &__header.has-bg-image {
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: center top;
   }
 
   &__header-inner {
@@ -14,6 +21,7 @@
   &__title {
     margin-bottom: @menu-title-margin;
     .menu-title;
+    color: @heading-color;
   }
 
   &__subtitle {

--- a/less/plugins/adapt-contrib-boxmenu/boxMenuItem.less
+++ b/less/plugins/adapt-contrib-boxmenu/boxMenuItem.less
@@ -1,17 +1,13 @@
 .boxmenu-item {
   &__inner {
+    margin: 0 @item-margin (@item-margin * 2);
     padding: @item-padding;
-    border: 1px solid @disabled;
+    border: 1px solid @item-color;
     border-radius: 5px;
-
-    @media (min-width: @device-width-medium) {
-      margin: 0 @item-margin (@item-margin * 2);
-    }
   }
 
   &__image-container {
     margin-bottom: @menu-item-image-margin;
-    .img-zoom();
   }
 
   &__title {
@@ -21,6 +17,7 @@
 
   &__body {
     margin-bottom: @menu-item-body-margin;
+    .menu-item-body;
   }
 
   &__body a {
@@ -33,5 +30,9 @@
 
   &__progress {
     margin-bottom: @menu-item-progress-margin;
+  }
+
+  &.has-img-zoom &__image-container {
+    .img-zoom();
   }
 }

--- a/less/plugins/adapt-contrib-graphic/graphic.less
+++ b/less/plugins/adapt-contrib-graphic/graphic.less
@@ -1,7 +1,5 @@
 .graphic {
-  &__image-container {
+  &.has-img-zoom &__image-container {
     .img-zoom();
-    // .img-zoom(@duration: .5s;);
-    // .img-zoom(1.25; .1s; ease-out;);
   }
 }

--- a/less/plugins/adapt-contrib-hotgraphic/hotgraphicPopup.less
+++ b/less/plugins/adapt-contrib-hotgraphic/hotgraphicPopup.less
@@ -12,7 +12,7 @@
   &__close {
     margin: @btn-margin / 2;
     padding: @btn-padding / 2;
-    background-color: transparent;
+    background-color: @notify-icon;
     color: @notify-icon-inverted;
     border-radius: 50%;
 
@@ -23,21 +23,9 @@
     }
   }
 
-  // &__controls,
-  // &__close {
-  //   background-color: @notify-icon;
-  //   color: @notify-icon-inverted;
-
-  //   .no-touch &:hover {
-  //     background-color: @notify-icon-hover;
-  //     color: @notify-icon-inverted-hover;
-  //     .transition(background-color @duration ease-in, color @duration ease-in;);
-  //   }
-  // }
-
   &__item-title {
     margin-bottom: @notify-title-margin;
-    .item-title;
+    .notify-title;
   }
 
   &__item-body {
@@ -54,7 +42,7 @@
     }
   }
 
-  &__item-image-container {
+  .hotgraphic.has-img-zoom &__item-image-container {
     .img-zoom();
   }
 }

--- a/less/plugins/adapt-contrib-languagePicker/languagePicker.less
+++ b/less/plugins/adapt-contrib-languagePicker/languagePicker.less
@@ -19,5 +19,14 @@
   &__body a {
     .link-text;
   }
+
+  &__languages-inner {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  &__language-btn {
+    margin: @item-margin / 2;
+  }
 }
 // --------------------------------------------------

--- a/less/plugins/adapt-contrib-media/media.less
+++ b/less/plugins/adapt-contrib-media/media.less
@@ -3,6 +3,19 @@
     margin-top: @item-margin;
   }
 
+  &__transcript-btn {
+    padding: @item-padding;
+    background-color: @item-color;
+    color: @item-color-inverted;
+    border-radius: 5px;
+
+    .no-touch &:hover {
+      background-color: @item-color-hover;
+      color: @item-color-inverted-hover;
+      .transition(background-color @duration ease-in, color @duration ease-in;);
+    }
+  }
+
   &__transcript-body-inline {
     margin-top: @item-margin;
     padding: @item-padding;

--- a/less/plugins/adapt-contrib-narrative/narrative.less
+++ b/less/plugins/adapt-contrib-narrative/narrative.less
@@ -44,7 +44,12 @@
     }
   }
 
-  &__slider-image-container {
+  &__strapline-btn.is-visited {
+    background-color: @visited;
+    color: @visited-inverted;
+  }
+
+  &.has-img-zoom &__slider-image-container {
     .img-zoom();
   }
 }

--- a/less/plugins/adapt-contrib-pageLevelProgress/pageLevelProgressIndicator.less
+++ b/less/plugins/adapt-contrib-pageLevelProgress/pageLevelProgressIndicator.less
@@ -25,6 +25,7 @@
 
 .pagelevelprogress__indicator-bar {
   background-color: @progress;
+  .transition(width @progress-duration linear);
 }
 
 // --------------------------------------------------

--- a/less/plugins/adapt-contrib-slider/slider.less
+++ b/less/plugins/adapt-contrib-slider/slider.less
@@ -3,43 +3,32 @@
   // Numbers
   // --------------------------------------------------
   &__number-container {
-    min-height: 2.5em;
+    min-height: 2.5rem;
   }
 
   &__number,
   &__number-selection,
   &__number-model-answer {
-    height: 2.5em;
-    width: 2.5em;
+    height: 2.5rem;
+    width: 2.5rem;
     line-height: 2.5;
     text-align: center;
     border-radius: 50%;
   }
 
-  // &__number {
-  //   background-color: @item-color;
-  //   color: @item-color-inverted;
-  // }
-
   &__widget:not(.is-disabled) .slider__number {
     cursor: pointer;
-
-    // .no-touch &:hover {
-    //   background-color: @item-color-hover;
-    //   color: @item-color-inverted-hover;
-    //   .transition(background-color @duration ease-in, color @duration ease-in;);
-    // }
   }
 
   &__number-selection {
-    background-color: @item-color-selected;
-    color: @item-color-inverted-selected;
+    background-color: @item-color;
+    color: @item-color-inverted;
     z-index: 5;
   }
 
   &__number-model-answer {
-    background-color: @item-color-selected;
-    color: @item-color-inverted-selected;
+    background-color: @item-color;
+    color: @item-color-inverted;
     z-index: 10;
   }
   // --------------------------------------------------
@@ -80,6 +69,16 @@
   &__fill {
     background-color: @item-color;
     box-shadow: none;
+  }
+
+  &__handle {
+    background-image: none;
+    border: 0;
+    box-shadow: 0 2px 5px fade(@black, 30%);
+  }
+
+  &__handle:after {
+    background-image: none;
   }
 }
 // --------------------------------------------------

--- a/less/plugins/adapt-contrib-text/text.less
+++ b/less/plugins/adapt-contrib-text/text.less
@@ -1,9 +1,9 @@
-.text.is-pull-quote {
-  .text__title {
+.text {
+  .text.is-pull-quote &__title {
     .pull-quote-title;
   }
 
-  .text__body {
+  .text.is-pull-quote &__body {
     .pull-quote-body;
   }
 }

--- a/less/project/theme-extras.less
+++ b/less/project/theme-extras.less
@@ -1,0 +1,104 @@
+// --------------------------------------------------
+// --------------------------------------------------
+// contentObject
+// --------------------------------------------------
+// --------------------------------------------------
+
+// --------------------------------------------------
+// Hide nav back button
+// --------------------------------------------------
+.hide-nav-back-btn .nav__back-btn {
+  .u-display-none;
+}
+// --------------------------------------------------
+
+// --------------------------------------------------
+// --------------------------------------------------
+// Block
+// --------------------------------------------------
+// --------------------------------------------------
+
+// --------------------------------------------------
+// Custom class added to block
+// Aligns child components centrally on the vertical axis
+// --------------------------------------------------
+.block.align-vert-center .component__container {
+  align-items: center;
+}
+// --------------------------------------------------
+
+// --------------------------------------------------
+// Extend width of block to max page width
+// --------------------------------------------------
+.block.extend-container .block__inner {
+  max-width: @max-width;
+}
+// --------------------------------------------------
+
+// --------------------------------------------------
+// Remove top padding from block
+// --------------------------------------------------
+.block.remove-top-padding .block__inner {
+  padding-top: 0;
+}
+// --------------------------------------------------
+
+// --------------------------------------------------
+// Remove bottom padding from block
+// --------------------------------------------------
+.block.remove-bottom-padding .block__inner {
+  padding-bottom: 0;
+}
+// --------------------------------------------------
+
+// --------------------------------------------------
+// Background color mixin
+// Add to block to enable
+// e.g. 'block-color black'
+// Note: both arguments must be predefined variables
+// --------------------------------------------------
+.block-color-mixin(transparent-light, black);
+.block-color-mixin(transparent-dark, white);
+.block-color-mixin(black, white);
+.block-color-mixin(background, background-inverted);
+
+.block-color-mixin(@color, @color-inverted) {
+
+.block-color.@{color} {
+  background-color: @@color;
+  color: @@color-inverted;
+
+  .block,
+  .component {
+    &__title,
+    &__body a,
+    &__instruction a {
+      color: @@color-inverted;
+    }
+  }
+
+  .pagelevelprogress {
+    &__indicator {
+      border-color: @@color-inverted;
+    }
+    &__indicator-inner {
+      background-color: @@color;
+    }
+    &__indicator-bar {
+      background-color: @@color-inverted;
+    }
+  }
+
+  .narrative {
+    &__progress {
+      background-color: fade(@@color-inverted, 50%);
+    }
+
+    &__progress.is-selected {
+      background-color: @@color-inverted;
+    }
+  }
+}
+
+}
+// --------------------------------------------------

--- a/properties.schema
+++ b/properties.schema
@@ -5,137 +5,614 @@
   "$ref": "http://localhost/plugins/content/theme/model.schema",
   "properties": {
     "variables": {
-      "_colors": {
+
+      "_global": {
         "type": "object",
         "required": false,
-        "title": "Colours",
+        "title": "Global",
         "properties": {
-          "primary": {
-            "title": "Primary",
-            "help": "This is the primary colour used to style the course, and is applied to component items and pop-up notifications.",
+          "font-color": {
+            "title": "Font colour",
             "type": "string",
             "inputType": "ColourPicker",
-            "default": "#078292"
+            "default": "#4D4D4D",
+            "help": "Global body font colour"
           },
-          "primary-inverted": {
-            "title": "Primary Inverted",
-            "help": "This is the inverted primary colour, and is applied to text that is displayed on elements coloured with primary.",
+          "font-color-inverted": {
+            "title": "Font colour inverted",
             "type": "string",
             "inputType": "ColourPicker",
-            "default": "#ffffff"
+            "default": "#FFFFFF",
+            "help": "Global body font colour inverted. Either a lightened/darkened alternative to Font colour."
           },
-          "secondary": {
-            "title": "Secondary",
-            "help": "This is the secondary colour used to style the course, and is applied to buttons.",
+          "link": {
+            "title": "Link colour",
             "type": "string",
             "inputType": "ColourPicker",
-            "default": "#4b4e4f"
+            "default": "",
+            "help": "Global link font colour"
           },
-          "secondary-inverted": {
-            "title": "Secondary Inverted",
-            "help": "This is the inverted secondary colour, and is applied to text that is displayed on elements coloured with secondary.",
+          "link-inverted": {
+            "title": "Link colour inverted",
             "type": "string",
             "inputType": "ColourPicker",
-            "default": "#ffffff"
+            "default": "",
+            "help": "Global link font colour inverted. Either a lightened/darkened alternative to Link colour."
           },
-          "tertiary": {
-            "title": "Tertiary",
-            "help": "This is the tertiary colour used to style the course, and is applied to the navigation bar.",
+          "link-hover": {
+            "title": "Link hover colour",
             "type": "string",
             "inputType": "ColourPicker",
-            "default": "#ffffff"
+            "default": "",
+            "help": "Global link font colour when hovered over"
           },
-          "tertiary-inverted": {
-            "title": "Tertiary Inverted",
-            "help": "This is the inverted tertiary colour, and is applied to text that is displayed on elements coloured with tertiary.",
+          "link-inverted-hover": {
+            "title": "Link hover colour inverted",
             "type": "string",
             "inputType": "ColourPicker",
-            "default": "#4b4e4f"
+            "default": "",
+            "help": "Global link font colour when hovered over inverted. Either a lightened/darkened alternative to Link hover colour."
           },
-          "quaternary": {
-            "title": "Quaternary",
-            "help": "This is the quaternary colour used to style the course, and is applied to the drawer.",
+          "heading-color": {
+            "title": "Heading colour",
             "type": "string",
             "inputType": "ColourPicker",
-            "default": "#37474f"
+            "default": "#36CDE8",
+            "help": "Global title colour"
           },
-          "quaternary-inverted": {
-            "title": "Quaternary Inverted",
-            "help": "This is the inverted quaternary colour, and is applied to text that is displayed on elements coloured with quaternary.",
+          "heading-color-inverted": {
+            "title": "Heading colour inverted",
             "type": "string",
             "inputType": "ColourPicker",
-            "default": "#ffffff"
-          },
-          "quinary": {
-            "title": "Quinary",
-            "help": "This is the quinary colour used to style the course, and is applied to the drawer.",
-            "type": "string",
-            "inputType": "ColourPicker",
-            "default": "#37474f"
-          },
-          "quinary-inverted": {
-            "title": "Quinary Inverted",
-            "help": "This is the inverted quinary colour, and is applied to text that is displayed on elements coloured with quinary.",
-            "type": "string",
-            "inputType": "ColourPicker",
-            "default": "#ffffff"
-          },
+            "default": "#FFFFFF",
+            "help": "Global title colour inverted. Either a lightened/darkened alternative to Title colour."
+          }
+        }
+      },
 
-          "foreground-color": {
-            "title": "Foreground",
-            "help": "This is the foreground colour, and is applied to all body text.",
+      "_items": {
+        "type": "object",
+        "required": false,
+        "title": "Items (Components)",
+        "properties": {
+          "item-color": {
+            "title": "Item colour",
             "type": "string",
             "inputType": "ColourPicker",
-            "default": "#4b4e4f"
+            "default": "#36CDE8",
+            "help": "Item background colour"
           },
-          "background-color": {
-            "title": "Background",
-            "help": "This is the background colour, and is applied to many elements including pages, articles and blocks.",
+          "item-color-inverted": {
+            "title": "Item colour - inverted",
             "type": "string",
             "inputType": "ColourPicker",
-            "default": "#ffffff"
+            "default": "#FFFFFF",
+            "help": "Item foreground colour"
           },
-          "foreground-color-inverted": {
-            "title": "Foreground Inverted",
-            "help": "This is the inverted foreground colour, and is applied to text on menus and page headers.",
+          "item-color-hover": {
+            "title": "Item colour - hover",
             "type": "string",
             "inputType": "ColourPicker",
-            "default": "#ffffff"
+            "default": "",
+            "help": "Item background colour when hovered over"
           },
-          "background-color-inverted": {
-            "title": "Background Inverted",
-            "help": "This is the inverted background colour, and is applied to menus and page headers.",
+          "item-color-inverted-hover": {
+            "title": "Item colour - inverted hover",
             "type": "string",
             "inputType": "ColourPicker",
-            "default": "#546e7a"
+            "default": "",
+            "help": "Item foreground colour when hovered over"
+          },
+          "item-color-selected": {
+            "title": "Item colour - selected",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Item background colour when selected"
+          },
+          "item-color-inverted-selected": {
+            "title": "Item colour - inverted selected",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Item foreground colour when selected"
+          },
+          "visited": {
+            "title": "Visited colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "#727272",
+            "help": "Item visited background colour"
+          },
+          "visited-inverted": {
+            "title": "Visited colour - inverted",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "#FFFFFF",
+            "help": "Item visited foreground colour"
+          }
+        }
+      },
+
+      "_buttons": {
+        "type": "object",
+        "required": false,
+        "title": "Buttons",
+        "properties": {
+          "btn-color": {
+            "title": "Button colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "#4D4D4D",
+            "help": "Question button background colour"
+          },
+          "btn-color-inverted": {
+            "title": "Button colour - inverted",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "#FFFFFF",
+            "help": "Question button foreground colour"
+          },
+          "btn-color-hover": {
+            "title": "Button colour - hover",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Question button background colour when hovered over"
+          },
+          "btn-color-inverted-hover": {
+            "title": "Button colour - inverted hover",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Question button foreground colour when hovered over"
+          },
+          "disabled": {
+            "title": "Disabled colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "#DDDDDD",
+            "help": "Question button disabled background colour"
+          },
+          "disabled-inverted": {
+            "title": "Disabled colour - inverted",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "#000000",
+            "help": "Question button disabled foreground colour"
+          }
+        }
+      },
+
+      "_validation": {
+        "type": "object",
+        "required": false,
+        "title": "Validation states",
+        "properties": {
+          "validation-success": {
+            "title": "Validation success colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "#065f28",
+            "help": "Question marking success background colour"
+          },
+          "validation-success-inverted": {
+            "title": "Validation success colour - inverted",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "#FFFFFF",
+            "help": "Question marking success foreground colour"
           },
           "validation-error": {
-            "title": "Validation error",
-            "help": "This is the validation error colour, and is applied to elements which display an incorrect field.",
+            "title": "Validation error colour",
             "type": "string",
             "inputType": "ColourPicker",
-            "default": "#f26c4f"
+            "default": "#ff0000",
+            "help": "Question marking error background colour"
           },
-          "validation-success": {
-            "title": "Validation success",
-            "help": "This is the validation success colour, and is applied to elements which display a correct field.",
+          "validation-error-inverted": {
+            "title": "Validation error colour - inverted",
             "type": "string",
             "inputType": "ColourPicker",
-            "default": "#82ca9c"
+            "default": "#FFFFFF",
+            "help": "Question marking error foreground colour"
+          }
+        }
+      },
+
+      "_progress": {
+        "type": "object",
+        "required": false,
+        "title": "Progress",
+        "properties": {
+          "progress": {
+            "title": "Progress colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "#9096A0",
+            "help": "Global progress fill colour"
           },
-          "disabled-color": {
-            "title": "Disabled",
-            "help": "This is the disabled colour, and is applied to elements which have been disabled.",
+          "progress-inverted": {
+            "title": "Progress colour - inverted",
             "type": "string",
             "inputType": "ColourPicker",
-            "default": "#727272"
+            "default": "#FFFFFF",
+            "help": "Global progress background colour"
           },
-          "disabled-color-inverted": {
-            "title": "Disabled Inverted",
-            "help": "This is the inverted disabled colour, and is applied to text on elements which have been disabled.",
+          "progress-border": {
+            "title": "Progress border colour",
             "type": "string",
             "inputType": "ColourPicker",
-            "default": "#cccccc"
+            "default": "#9096A0",
+            "help": "Global progress border colour"
+          }
+        }
+      },
+
+      "_nav": {
+        "type": "object",
+        "required": false,
+        "title": "Navigation",
+        "properties": {
+          "nav": {
+            "title": "Nav colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "#FFFFFF",
+            "help": "Navigation background colour"
+          },
+          "nav-inverted": {
+            "title": "Nav colour - inverted",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "#9096A0",
+            "help": "Navigation foreground colour"
+          },
+          "nav-icon": {
+            "title": "Nav icon colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Navigation icon background colour"
+          },
+          "nav-icon-inverted": {
+            "title": "Nav icon colour - inverted",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Navigation icon foreground colour"
+          },
+          "nav-icon-hover": {
+            "title": "Nav icon colour - hover",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Navigation icon background colour when hovered over"
+          },
+          "nav-icon-inverted-hover": {
+            "title": "Nav icon colour - inverted hover",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Navigation icon foreground colour when hovered over"
+          },
+          "nav-progress": {
+            "title": "Nav progress",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Navigation progress fill colour"
+          },
+          "nav-progress-inverted": {
+            "title": "Nav progress - inverted",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Navigation progress background colour"
+          },
+          "nav-progress-border": {
+            "title": "Nav progress border colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Navigation progress border colour"
+          },
+          "nav-progress-hover": {
+            "title": "Nav progress - hover",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Navigation progress fill colour when hovered over"
+          },
+          "nav-progress-inverted-hover": {
+            "title": "Nav progress - inverted hover",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Navigation progress background colour when hovered over"
+          },
+          "nav-progress-border-hover": {
+            "title": "Nav progress border colour - hover",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Navigation progress border colour when hovered over"
+          }
+        }
+      },
+
+      "_notify": {
+        "type": "object",
+        "required": false,
+        "title": "Notify",
+        "properties": {
+          "notify": {
+            "title": "Notify colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "#36CDE8",
+            "help": "Notify background colour"
+          },
+          "notify-inverted": {
+            "title": "Notify colour - inverted",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "#FFFFFF",
+            "help": "Notify foreground colour"
+          },
+          "notify-link": {
+            "title": "Notify link colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Notify link font colour"
+          },
+          "notify-link-hover": {
+            "title": "Notify link colour - hover",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Notify link font colour when hovered over"
+          },
+          "notify-btn": {
+            "title": "Notify button colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Notify button background colour"
+          },
+          "notify-btn-inverted": {
+            "title": "Notify button colour - inverted",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Notify button foreground colour"
+          },
+          "notify-btn-hover": {
+            "title": "Notify button colour - hover",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Notify button backgroound colour when hovered over"
+          },
+          "notify-btn-inverted-hover": {
+            "title": "Notify button colour - inverted hover",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Notify button foreground colour when hovered over"
+          },
+          "notify-icon": {
+            "title": "Notify icon colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Notify icon background colour"
+          },
+          "notify-icon-inverted": {
+            "title": "Notify icon colour - inverted",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Notify icon foreground colour"
+          },
+          "notify-icon-hover": {
+            "title": "Notify icon colour - hover",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Notify icon background colour when hovered over"
+          },
+          "notify-icon-inverted-hover": {
+            "title": "Notify icon colour - inverted hover",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Notify icon foregroound colour when hovered over"
+          }
+        }
+      },
+
+      "_drawer": {
+        "type": "object",
+        "required": false,
+        "title": "Drawer",
+        "properties": {
+          "drawer": {
+            "title": "Drawer colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "#263944",
+            "help": "Drawer background colour"
+          },
+          "drawer-inverted": {
+            "title": "Drawer colour - inverted",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "#FFFFFF",
+            "help": "Drawer foreground colour"
+          },
+          "drawer-link": {
+            "title": "Drawer link colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Drawer link font colour"
+          },
+          "drawer-link-hover": {
+            "title": "Drawer link colour - hover",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Drawer link font colour when hovered over"
+          },
+          "drawer-icon": {
+            "title": "Drawer icon colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Drawer icon background colour"
+          },
+          "drawer-icon-inverted": {
+            "title": "Drawer icon colour - inverted",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Drawer icon foreground colour"
+          },
+          "drawer-icon-hover": {
+            "title": "Drawer icon colour - hover",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Drawer icon background colour when hovered over"
+          },
+          "drawer-icon-inverted-hover": {
+            "title": "Drawer icon colour - inverted hover",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Drawer icon foreground colour when hovered over"
+          },
+          "drawer-item": {
+            "title": "Drawer item colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Drawer item background colour"
+          },
+          "drawer-item-inverted": {
+            "title": "Drawer item colour - inverted",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Drawer item foreground colour"
+          },
+          "drawer-item-hover": {
+            "title": "Drawer item colour - hover",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Drawer item background colour when hovered over"
+          },
+          "drawer-item-inverted-hover": {
+            "title": "Drawer item colour - inverted hover",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Drawer item foreground colour when hovered over"
+          },
+          "drawer-item-selected": {
+            "title": "Drawer item colour - selected",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Drawer item background colour when selected"
+          },
+          "drawer-item-inverted-selected": {
+            "title": "Drawer item colour - inverted selected",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Drawer item foreground colour when selected"
+          },
+          "drawer-progress": {
+            "title": "Drawer progress colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Drawer progress fill colour"
+          },
+          "drawer-progress-inverted": {
+            "title": "Drawer progress colour - inverted",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Drawer progress background colour"
+          },
+          "drawer-progress-border": {
+            "title": "Drawer progress border colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Drawer progress border colour"
+          },
+          "drawer-progress-hover": {
+            "title": "Drawer progress colour - hover",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Drawer progress fill colour when hovered over"
+          },
+          "drawer-progress-inverted-hover": {
+            "title": "Drawer progress colour - inverted hover",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Drawer progress backgroud colour when hovered over"
+          },
+          "drawer-progress-border-hover": {
+            "title": "Drawer progress border colour - hover",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Drawer progress border colour when hovered over"
+          }
+        }
+      },
+
+      "_misc": {
+        "type": "object",
+        "required": false,
+        "title": "Misc",
+        "properties": {
+          "background": {
+            "title": "Background colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "#000000",
+            "help": ""
+          },
+          "background-inverted": {
+            "title": "Background colour - inverted",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "#FFFFFF",
+            "help": ""
+          },
+          "shadow": {
+            "title": "Shadow colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "#000000",
+            "help": ""
+          },
+          "shadow-inverted": {
+            "title": "Shadow colour - inverted",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "#FFFFFF",
+            "help": ""
           }
         }
       }
@@ -144,8 +621,12 @@
       "type": "object",
       "required": true,
       "properties": {
-        "config": {},
-        "course": {},
+        "config": {
+          "type": "object"
+        },
+        "course": {
+          "type": "object"
+        },
         "contentobject": {
           "type": "object",
           "properties": {
@@ -153,15 +634,76 @@
               "type": "object",
               "required": false,
               "properties": {
+                "_backgroundImage": {
+                  "type": "object",
+                  "required": false,
+                  "legend": "Page background image",
+                  "properties": {
+                    "_large": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "inputType": "Asset:image",
+                      "validators": [],
+                      "help": "Large background image - used on desktop"
+                    },
+                    "_medium": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "inputType": "Asset:image",
+                      "validators": [],
+                      "help": "Medium background image - used on tablet"
+                    },
+                    "_small": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "inputType": "Asset:image",
+                      "validators": [],
+                      "help": "Small background image - used on mobile"
+                    }
+                  }
+                },
+                "_backgroundStyles": {
+                  "type": "object",
+                  "required": false,
+                  "legend": "Page background image styles",
+                  "properties": {
+                    "_backgroundRepeat": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "inputType": {"type":"Select", "options":["repeat","repeat-x","repeat-y","no-repeat"]},
+                      "title": "Set if/how the background image repeats",
+                      "help": "Repeat-x: The background image is repeated only horizontally. Repeat-y: The background image is repeated only vertically."
+                    },
+                    "_backgroundSize": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "inputType": {"type":"Select", "options":["auto","cover","contain"]},
+                      "title": "Set the size of the background image",
+                      "help": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible."
+                    },
+                    "_backgroundPosition": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "inputType": {"type":"Select", "options":["left top","left center","left bottom","center top","center center","center bottom","right top","right center","right bottom"]},
+                      "title": "Set the position of the background image",
+                      "help": "The first value is the horizontal position and the second value is the vertical."
+                    }
+                  }
+                },
                 "_pageHeader": {
                   "type": "object",
                   "required": false,
-                  "title": "Page Header",
                   "properties": {
                     "_backgroundImage": {
                       "type": "object",
                       "required": false,
-                      "title": "Page header background image",
+                      "legend": "Page header background image",
                       "properties": {
                         "_large": {
                           "type": "string",
@@ -189,10 +731,41 @@
                         }
                       }
                     },
+                    "_backgroundStyles": {
+                      "type": "object",
+                      "required": false,
+                      "legend": "Page header background image styles",
+                      "properties": {
+                        "_backgroundRepeat": {
+                          "type": "string",
+                          "required": false,
+                          "default": "",
+                          "inputType": {"type":"Select", "options":["repeat","repeat-x","repeat-y","no-repeat"]},
+                          "title": "Set if/how the background image repeats",
+                          "help": "Repeat-x: The background image is repeated only horizontally. Repeat-y: The background image is repeated only vertically."
+                        },
+                        "_backgroundSize": {
+                          "type": "string",
+                          "required": false,
+                          "default": "",
+                          "inputType": {"type":"Select", "options":["auto","cover","contain"]},
+                          "title": "Set the size of the background image",
+                          "help": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible."
+                        },
+                        "_backgroundPosition": {
+                          "type": "string",
+                          "required": false,
+                          "default": "",
+                          "inputType": {"type":"Select", "options":["left top","left center","left bottom","center top","center center","center bottom","right top","right center","right bottom"]},
+                          "title": "Set the position of the background image",
+                          "help": "The first value is the horizontal position and the second value is the vertical."
+                        }
+                      }
+                    },
                     "_minimumHeights": {
                       "type": "object",
                       "required": false,
-                      "title": "Minimum height",
+                      "legend": "Page header minimum height",
                       "properties": {
                         "_large": {
                           "type": "number",
@@ -233,70 +806,65 @@
               "type": "object",
               "required": false,
               "properties": {
-                "type": "object",
-                "required": false,
-                "title": "Article",
-                "properties": {
-                  "_backgroundImage": {
-                    "type": "object",
-                    "required": false,
-                    "title": "Page header background image",
-                    "properties": {
-                      "_large": {
-                        "type": "string",
-                        "required": false,
-                        "default": "",
-                        "inputType": "Asset:image",
-                        "validators": [],
-                        "help": "Large background image - used on desktop"
-                      },
-                      "_medium": {
-                        "type": "string",
-                        "required": false,
-                        "default": "",
-                        "inputType": "Asset:image",
-                        "validators": [],
-                        "help": "Medium background image - used on tablet"
-                      },
-                      "_small": {
-                        "type": "string",
-                        "required": false,
-                        "default": "",
-                        "inputType": "Asset:image",
-                        "validators": [],
-                        "help": "Small background image - used on mobile"
-                      }
+                "_backgroundImage": {
+                  "type": "object",
+                  "required": false,
+                  "legend": "Article background image",
+                  "properties": {
+                    "_large": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "inputType": "Asset:image",
+                      "validators": [],
+                      "help": "Large background image - used on desktop"
+                    },
+                    "_medium": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "inputType": "Asset:image",
+                      "validators": [],
+                      "help": "Medium background image - used on tablet"
+                    },
+                    "_small": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "inputType": "Asset:image",
+                      "validators": [],
+                      "help": "Small background image - used on mobile"
                     }
-                  },
-                  "_minimumHeights": {
-                    "type": "object",
-                    "required": false,
-                    "title": "Minimum height",
-                    "properties": {
-                      "_large": {
-                        "type": "number",
-                        "required": false,
-                        "default": "",
-                        "inputType": "Number",
-                        "validators": ["number"],
-                        "help": "Minimum height should only be used in instances where the article height needs to be greater than the content e.g. to prevent a background image being cropped"
-                      },
-                      "_medium": {
-                        "type": "number",
-                        "required": false,
-                        "default": "",
-                        "inputType": "Number",
-                        "validators": ["number"],
-                        "help": "Minimum height should only be used in instances where the article height needs to be greater than the content e.g. to prevent a background image being cropped"
-                      },
-                      "_small": {
-                        "type": "number",
-                        "required": false,
-                        "default": "",
-                        "inputType": "Number",
-                        "validators": ["number"],
-                        "help": "Minimum height should only be used in instances where the article height needs to be greater than the content e.g. to prevent a background image being cropped"
-                      }
+                  }
+                },
+                "_backgroundStyles": {
+                  "type": "object",
+                  "required": false,
+                  "legend": "Article background image styles",
+                  "properties": {
+                    "_backgroundRepeat": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "inputType": {"type":"Select", "options":["repeat","repeat-x","repeat-y","no-repeat"]},
+                      "title": "Set if/how the background image repeats",
+                      "help": "Repeat-x: The background image is repeated only horizontally. Repeat-y: The background image is repeated only vertically."
+                    },
+                    "_backgroundSize": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "inputType": {"type":"Select", "options":["auto","cover","contain"]},
+                      "title": "Set the size of the background image",
+                      "help": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible."
+                    },
+                    "_backgroundPosition": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "inputType": {"type":"Select", "options":["left top","left center","left bottom","center top","center center","center bottom","right top","right center","right bottom"]},
+                      "title": "Set the position of the background image",
+                      "help": "The first value is the horizontal position and the second value is the vertical."
                     }
                   }
                 }
@@ -311,46 +879,72 @@
               "type": "object",
               "required": false,
               "properties": {
-                "type": "object",
-                "required": false,
-                "title": "Block",
-                "properties": {
-                  "_backgroundImage": {
-                    "type": "object",
-                    "required": false,
-                    "title": "Page header background image",
-                    "properties": {
-                      "_large": {
-                        "type": "string",
-                        "required": false,
-                        "default": "",
-                        "inputType": "Asset:image",
-                        "validators": [],
-                        "help": "Large background image - used on desktop"
-                      },
-                      "_medium": {
-                        "type": "string",
-                        "required": false,
-                        "default": "",
-                        "inputType": "Asset:image",
-                        "validators": [],
-                        "help": "Medium background image - used on tablet"
-                      },
-                      "_small": {
-                        "type": "string",
-                        "required": false,
-                        "default": "",
-                        "inputType": "Asset:image",
-                        "validators": [],
-                        "help": "Small background image - used on mobile"
-                      }
+                "_backgroundImage": {
+                  "type": "object",
+                  "required": false,
+                  "legend": "Block background image",
+                  "properties": {
+                    "_large": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "inputType": "Asset:image",
+                      "validators": [],
+                      "help": "Large background image - used on desktop"
+                    },
+                    "_medium": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "inputType": "Asset:image",
+                      "validators": [],
+                      "help": "Medium background image - used on tablet"
+                    },
+                    "_small": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "inputType": "Asset:image",
+                      "validators": [],
+                      "help": "Small background image - used on mobile"
+                    }
+                  }
+                },
+                "_backgroundStyles": {
+                  "type": "object",
+                  "required": false,
+                  "legend": "Block background image styles",
+                  "properties": {
+                    "_backgroundRepeat": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "inputType": {"type":"Select", "options":["repeat","repeat-x","repeat-y","no-repeat"]},
+                      "title": "Set if/how the background image repeats",
+                      "help": "Repeat-x: The background image is repeated only horizontally. Repeat-y: The background image is repeated only vertically."
+                    },
+                    "_backgroundSize": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "inputType": {"type":"Select", "options":["auto","cover","contain"]},
+                      "title": "Set the size of the background image",
+                      "help": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible."
+                    },
+                    "_backgroundPosition": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "inputType": {"type":"Select", "options":["left top","left center","left bottom","center top","center center","center bottom","right top","right center","right bottom"]},
+                      "title": "Set the position of the background image",
+                      "help": "The first value is the horizontal position and the second value is the vertical."
                     }
                   }
                 },
                 "_minimumHeights": {
                   "type": "object",
                   "required": false,
-                  "title": "Minimum height",
+                  "legend": "Block minimum height",
                   "properties": {
                     "_large": {
                       "type": "number",
@@ -377,12 +971,23 @@
                       "help": "Minimum height should only be used in instances where the block height needs to be greater than the content e.g. to prevent a background image being cropped"
                     }
                   }
+                },
+                "_isDividerBlock": {
+                  "type": "boolean",
+                  "required": false,
+                  "default": false,
+                  "title": "Divider block?",
+                  "inputType": "Checkbox",
+                  "validators": [],
+                  "help": "If enabled, applies a divider class to the block"
                 }
               }
             }
           }
         },
-        "component": {}
+        "component": {
+          "type": "object"
+        }
       }
     }
   }

--- a/theme.json
+++ b/theme.json
@@ -1,7 +1,0 @@
-{
-    "screenSize": {
-        "large": 900,
-        "medium": 760,
-        "small": 520
-    }
-}


### PR DESCRIPTION
This is related to framework issue #2502.

Currently the drawer-toolbar has a transparent background. This PR assigns the @drawer-color to it background. This solid background i necessary to allow items to scroll behind it unseen.