### PR TITLE
Added mejs player override file

### DIFF
--- a/less/plugins/adapt-contrib-media/media.less
+++ b/less/plugins/adapt-contrib-media/media.less
@@ -24,32 +24,4 @@
   &__transcript-body-inline a {
     .link-text;
   }
-
-  // --------------------------------------------------
-  // Overrides for media player controls - to finish
-  // --------------------------------------------------
-  // .mejs-container {
-  //   .mejs-controls {
-  //     background-image: none;
-  //     background-color: red;
-  //   }
-
-  //   .mejs-time-rail {
-  //     .mejs-time-total {
-  //       background-image: none;
-  //       background-color: white;
-  //     }
-
-  //     .mejs-time-loaded {
-  //       background-image: none;
-  //       background-color: green;
-  //     }
-
-  //     .mejs-time-current {
-  //       background-image: none;
-  //       background-color: orange;
-  //     }
-  //   }
-  // }
-  // --------------------------------------------------
 }

--- a/less/plugins/adapt-contrib-media/mep.less
+++ b/less/plugins/adapt-contrib-media/mep.less
@@ -1,0 +1,237 @@
+// --------------------------------------------------
+// Overrides for mejs player
+// --------------------------------------------------
+@mejs-color: @black;
+@mejs-color-inverted: @white;
+
+@mejs-icon: @white;
+
+@mejs-time-current: @white;
+@mejs-time-loaded: darken(@white, 25%);
+@mejs-time-total: darken(@white, 50%);
+
+@mejs-controls-height: 2rem;
+@mejs-time-rail-height: 0.5rem;
+@mejs-margin: 0.5rem;
+
+@mejs-time-size: 0.75rem;
+
+@mejs-time-float-size: 0.75rem;
+@mejs-time-float-width: 2rem;
+
+@mejs-cc-size: 0.75rem;
+
+.mejs-container {
+  // Colour overrides
+  // --------------------------------------------------
+  .mejs-controls {
+    background: none;
+    background-color: @mejs-color;
+  }
+
+  .mejs-controls .mejs-time,
+  .mejs-controls .mejs-captions-button .mejs-captions-selector ul li {
+    color: @mejs-color-inverted;
+  }
+
+  .mejs-controls .mejs-button button {
+    color: @mejs-icon;
+  }
+
+  .mejs-controls .mejs-time-rail .mejs-time-total,
+  .mejs-controls .mejs-volume-button .mejs-volume-slider .mejs-volume-total {
+    background: none;
+    background-color: @mejs-time-total;
+  }
+
+  .mejs-controls .mejs-time-rail .mejs-time-loaded {
+    background: none;
+    background-color: @mejs-time-loaded;
+  }
+
+  .mejs-controls .mejs-time-rail .mejs-time-current,
+  .mejs-controls .mejs-volume-button .mejs-volume-slider .mejs-volume-current {
+    background: none;
+    background-color: @mejs-time-current;
+  }
+
+  .mejs-controls .mejs-captions-button .mejs-captions-selector,
+  .mejs-controls .mejs-volume-button .mejs-volume-slider {
+    background: none;
+    background-color: @mejs-color;
+  }
+
+  .mejs-controls .mejs-volume-button .mejs-volume-slider .mejs-volume-handle {
+    background: none;
+    background-color: @mejs-time-current;
+  }
+
+  // Icon overrides
+  // icon classes must be defined in core/fonts/vanilla or
+  // a custom font must be set up in the theme
+  // --------------------------------------------------
+  .mejs-controls .mejs-play button {
+    .icon-video-play;
+  }
+
+  .mejs-controls .mejs-pause button {
+    .icon-video-pause;
+  }
+
+  .mejs-controls .mejs-fullscreen-button button {
+    .icon-video-fullscreen;
+  }
+
+  .mejs-controls .mejs-unfullscreen button {
+    .icon-video-exit-fullscreen;
+  }
+
+  .mejs-controls .mejs-mute button {
+    .icon-sound;
+  }
+
+  .mejs-controls .mejs-unmute button {
+    .icon-sound-mute;
+  }
+
+  .mejs-controls .mejs-captions-button button {
+    .icon-video-captions-off-2;
+  }
+
+  .mejs-controls .mejs-captions-enabled button {
+    .icon-video-captions;
+  }
+
+  // Player controls
+  // --------------------------------------------------
+  .mejs-controls {
+    height: @mejs-controls-height;
+  }
+
+  .mejs-controls .mejs-time-rail {
+    height: @mejs-time-rail-height;
+    margin: ((@mejs-controls-height - @mejs-time-rail-height) / 2) @mejs-margin;
+    padding: 0;
+  }
+
+  .mejs-controls .mejs-time-rail span {
+    height: @mejs-time-rail-height;
+  }
+
+  .mejs-controls .mejs-time-rail .mejs-time-total {
+    height: @mejs-time-rail-height;
+    margin: 0;
+  }
+
+  .mejs-controls .mejs-time {
+    height: @mejs-time-size;
+    margin: ((@mejs-time-size / 2) + (@mejs-margin / 2)) @mejs-margin;
+    padding: 0;
+    font-size: @mejs-time-size;
+    line-height: 1;
+  }
+
+  // Button icon style overrides
+  // --------------------------------------------------
+  .mejs-controls .mejs-button {
+    height: @icon-size;
+    width: @icon-size;
+    margin: @mejs-margin / 2;
+  }
+
+  .mejs-controls .mejs-button button {
+    .icon;
+    height: @icon-size;
+    width: @icon-size;
+    margin: 0;
+    background: none;
+  }
+
+  // Current time pop float on time rail hover
+  // --------------------------------------------------
+  .mejs-controls .mejs-time-rail .mejs-time-float {
+    top: -1.5rem;
+    height: calc(~'@{mejs-time-float-size} + 2px');
+    width: calc(~'@{mejs-time-float-width} + 2px');
+    margin-left: -@mejs-time-float-width / 2;
+    background: none;
+    background-color: @white;
+    color: @black;
+    border-color: @black;
+  }
+
+  .mejs-controls .mejs-time-rail .mejs-time-float-current {
+    height: @mejs-time-float-size;
+    width: @mejs-time-float-width;
+    margin: 0;
+    font-size: @mejs-time-float-size;
+    line-height: 1;
+  }
+
+  .mejs-controls .mejs-time-rail .mejs-time-float-corner {
+    top: @mejs-time-float-width / 2;
+    left: @mejs-time-float-width / 2;
+    .transform(translate(-50%,-50%));
+    border-color: @white transparent transparent transparent;
+  }
+
+  .mejs-controls .mejs-time-rail span {
+    -webkit-border-radius: 0;
+    -moz-border-radius: 0;
+    border-radius: 0;
+  }
+
+  // Closed captions pop up selector
+  // --------------------------------------------------
+  .mejs-controls .mejs-captions-button .mejs-captions-selector {
+    bottom: @mejs-controls-height - @mejs-margin;
+    left: -@mejs-margin / 2;
+    right: auto;
+    width: 6rem;
+    height: 6.5rem;
+    padding: @mejs-margin;
+    overflow-y: scroll;
+    font-size: @mejs-cc-size;
+    line-height: 1;
+  }
+
+  .mejs-controls .mejs-captions-button .mejs-captions-selector ul li {
+    display: flex;
+    align-items: center;
+    margin: 0;
+    padding: @mejs-margin / 2;
+  }
+
+  .mejs-controls .mejs-captions-button .mejs-captions-selector ul li input {
+    margin: 0;
+    float: none;
+  }
+
+  .mejs-controls .mejs-captions-button .mejs-captions-selector ul li label {
+    float: none;
+    width: auto;
+    margin-left: @mejs-margin;
+    padding: 0;
+    font-size: @mejs-cc-size;
+    line-height: 1;
+  }
+
+  // Closed captions
+  // --------------------------------------------------
+  .mejs-captions-layer {
+    font-size: @body-size;
+    line-height: @body-line-height;
+    color: inherit;
+  }
+
+  .mejs-captions-position-hover {
+    bottom: @mejs-controls-height + @mejs-time-rail-height;
+  }
+
+  .mejs-captions-text {
+    padding: 0.25rem;
+    background: none;
+    background-color: @black;
+    color: @white;
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/adaptlearning/adapt_framework/issues/2689

* Added a new file, mep.less, that overrides the standard mejs player controls styling by:
  * Converting px to rems
  * Introducing variables to change the main colour of the player bar, the icons within the player bar, and the time rail
  * Converted player controls from images to icons to allow for bespoke icons to be added with ease

This PR is dependant on a Framework PR which includes the new media player icons: https://github.com/adaptlearning/adapt_framework/pull/2691