### PR TITLE
Added boxMenu group support

### DIFF
--- a/less/plugins/adapt-contrib-boxmenu/boxMenuGroup.less
+++ b/less/plugins/adapt-contrib-boxmenu/boxMenuGroup.less
@@ -1,0 +1,25 @@
+.boxmenu-group {
+  &__header-inner {
+    .l-container-padding(@menu-header-padding-ver, @menu-header-padding-hoz);
+  }
+
+  &__title {
+    margin-bottom: @menu-subtitle-margin;
+    .menu-subtitle;
+  }
+
+  &__body {
+    margin-bottom: @menu-body-margin;
+    .menu-body;
+  }
+
+  &__instruction {
+    margin-bottom: @menu-instruction-margin;
+    .menu-instruction;
+  }
+
+  &__body a,
+  &__instruction a {
+    .link-text;
+  }
+}


### PR DESCRIPTION
Related to feature request in this issue: https://github.com/adaptlearning/adapt_framework/issues/2702

* Adds vanilla theme styling to box menu group sections 