### PR TITLE
Modify slider.less styles

### DIFF
--- a/less/plugins/adapt-contrib-slider/slider.less
+++ b/less/plugins/adapt-contrib-slider/slider.less
@@ -21,9 +21,12 @@
   }
 
   &__number-selection {
-    background-color: @item-color;
-    color: @item-color-inverted;
+    background-color: @item-color-inverted;
+    border: 0.125rem solid @item-color;
+    box-sizing: border-box;
+    color: @item-color;
     z-index: 5;
+    line-height: 2.25rem;
   }
 
   &__number-model-answer {
@@ -67,11 +70,12 @@
   }
 
   &__fill {
-    background-color: @item-color;
+    background-color: @greyDark;
     box-shadow: none;
   }
 
   &__handle {
+    background-color: @item-color;
     background-image: none;
     border: 0;
     box-shadow: 0 2px 5px fade(@black, 30%);


### PR DESCRIPTION
I have one very low-contrast monitor at home and with it, I'm having a difficult time seeing the slider fill and handle. The handle is the active button, so I believe it should take on the primary color of the theme. This causes a little conflict with the range numbers being the same color, so I've changed the selected range color to instead include a rounded border with the primary-color. Lastly, I've changed the fill color to the greyDark color in the theme for better contrast.