### PR TITLE
Removed plp specificity for *-title-inner

### DIFF
--- a/less/plugins/adapt-contrib-pageLevelProgress/pageLevelProgressIndicator.less
+++ b/less/plugins/adapt-contrib-pageLevelProgress/pageLevelProgressIndicator.less
@@ -5,20 +5,6 @@
   vertical-align: middle;
 }
 
-.pagelevelprogress__indicator {
-  & + .menu,
-  & + .menu-item,
-  & + .page,
-  & + .article,
-  & + .block,
-  & + .component {
-    &__title-inner {
-      display: inline;
-      vertical-align: middle;
-    }
-  }
-}
-
 // Global progress lozenge
 // --------------------------------------------------
 .pagelevelprogress {


### PR DESCRIPTION
Related issue: https://github.com/adaptlearning/adapt_framework/issues/2912

* Removed plp specificity 
* Moved *-title-inner CSS to core