### PR TITLE
issue/3235 exclude locked drawer items from inheriting hover style

### DIFF
--- a/less/core/drawerItem.less
+++ b/less/core/drawerItem.less
@@ -6,7 +6,7 @@
     border-bottom: 1px solid @drawer-item-hover;
     color: @drawer-item-inverted;
 
-    .no-touch &:not(.is-disabled):hover {
+    .no-touch &:not(.is-disabled):not(.is-locked):hover {
       background-color: @drawer-item-hover;
       color: @drawer-item-inverted-hover;
       .transition(background-color @duration ease-in, color @duration ease-in;);


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt_framework/issues/3235

### Fixed
* Exclude locked drawer item from inheriting hover style