### PR TITLE
update colors to meet AA color contrast

### DIFF
--- a/less/_defaults/_colors.less
+++ b/less/_defaults/_colors.less
@@ -1,6 +1,6 @@
 // Colour definitions
 // --------------------------------------------------
-@blue: #36CDE8;
+@blue: #117F93;
 @blueDark: #263944;
 @grey: #9096A0;
 @greyDark: #4D4D4D;


### PR DESCRIPTION
resolves https://github.com/adaptlearning/adapt_framework/issues/3171

It's the combination of blue (#36CDE8) and white (#FFFFFF) where Adapt fails to meet AA colour contrast. This combination of colours impacts titles, component items, and notify. Darkening the current blue (#36CDE8) by 24% meets the minimum colour contrast. I tried other colour combinations using the existing palette but darkening the existing blue was the easiest on the eye.