### PR TITLE
GMCQ attribution fix

### DIFF
--- a/less/core/attribution.less
+++ b/less/core/attribution.less
@@ -16,4 +16,5 @@
 // Override position: absolute; as it won't work with current GMCQ structure
 .gmcq__attribution {
   position: relative;
+  display: flex;
 }


### PR DESCRIPTION
Resolves https://github.com/adaptlearning/adapt-contrib-vanilla/issues/332

* Add `display: flex;` to `.gmcq__attribution` element to resolve visual display error 

Dependency:

https://github.com/adaptlearning/adapt-contrib-core/pull/133
https://github.com/adaptlearning/adapt-contrib-gmcq/pull/150