### PR TITLE
#337 Add selected underline to filter tab

### DIFF
--- a/less/_defaults/_colors.less
+++ b/less/_defaults/_colors.less
@@ -161,6 +161,7 @@
 
 @drawer-item-selected: darken(@drawer-item, 20%);
 @drawer-item-inverted-selected: @drawer-item-inverted;
+@drawer-item-selected-underline: @drawer-item-inverted;
 
 @drawer-progress: @drawer-item-inverted;
 @drawer-progress-inverted: @drawer-item;

--- a/less/plugins/adapt-contrib-resources/resources.less
+++ b/less/plugins/adapt-contrib-resources/resources.less
@@ -21,6 +21,7 @@
   &__filter-btn.is-selected {
     background-color: @drawer-item-selected;
     color: @drawer-item-inverted-selected;
+    box-shadow: inset 0 -10px 0 -7px @drawer-item-selected-underline;
   }
 
   &__item-btn {

--- a/less/plugins/adapt-contrib-resources/resources.less
+++ b/less/plugins/adapt-contrib-resources/resources.less
@@ -21,7 +21,7 @@
   &__filter-btn.is-selected {
     background-color: @drawer-item-selected;
     color: @drawer-item-inverted-selected;
-    box-shadow: inset 0 -10px 0 -7px @drawer-item-selected-underline;
+    box-shadow: inset 0 -0.625rem 0 -0.4375rem @drawer-item-selected-underline;
   }
 
   &__item-btn {


### PR DESCRIPTION
I propose adding an underline to the selected tab.  The underline color can be set with a new color variable, @drawer-item-selected-underline, which defaults to @drawer-item-inverted.

Resolves #337

![underline](https://user-images.githubusercontent.com/898168/176546220-ef2978d1-5b93-45b7-901c-f50cb3cb5179.jpg)
