### PR TITLE
Fix: Remove unnecessary styling from reverse-desktop-order (#356)

### DIFF
--- a/less/project/theme-extras.less
+++ b/less/project/theme-extras.less
@@ -58,31 +58,10 @@
 // e.g. Left layout components would still render first in the DOM order
 // but visually appear on the right hand side above the medium breakpoint. The
 // components woud vertically stack as per the DOM order below the breakpoint
-// --------------------------------------------------
 .block.reverse-desktop-order .component {
   @media (min-width: @device-width-medium) {
     &__container {
       flex-direction: row-reverse;
-    }
-
-    &.is-left {
-      padding-right: inherit;
-      padding-left: @component-padding-hoz;
-
-      .dir-rtl & {
-        padding-left: inherit;
-        padding-right: @component-padding-hoz;
-      }
-    }
-
-    &.is-right {
-      padding-left: inherit;
-      padding-right: @component-padding-hoz;
-
-      .dir-rtl & {
-        padding-right: inherit;
-        padding-left: @component-padding-hoz;
-      }
     }
   }
 }


### PR DESCRIPTION
Fixes: #356 
### Fix
* Removes the outdated component left and right padding from the `reverse-desktop-order` custom class
