### PR TITLE
Fix: Firefox attribution fix (fixes #352)

### DIFF
--- a/less/core/attribution.less
+++ b/less/core/attribution.less
@@ -1,5 +1,6 @@
 .has-attribution {
   position: relative;
+  display: block;
 }
 
 .component__attribution {


### PR DESCRIPTION
Fixes: #352 

### Fix
* Adds `display: block;` to image parent container when attribution is present. Issue caused by `<span>` have an inline display property
