### PR TITLE
Docs: Removed accordion / hotgraphic item image classes (fixes #365)

### DIFF
--- a/example.json
+++ b/example.json
@@ -200,17 +200,7 @@ Breakpoints are assigned from the smallest screen resolution to the widest until
 "_classes": "col-xl-8",
 "_comment": "On screens above 1440px the component fills 8 out of the 12 columns available.",
 
-Accordion item
-"_classes": "align-image-left",
-"_comment": "Aligns the image to the left of the body text on desktop, defaults to underneath on smaller screens.",
-
-"_classes": "align-image-right",
-"_comment": "Aligns the image to the right of the body text on desktop, defaults to underneath on smaller screens.",
-
 Hotgraphic item
-"_classes": "align-image-left",
-"_comment": "Align the hotgraphic pop up image to the left on desktop.",
-
 "_classes": "hide-desktop-image",
 "_comment": "Hide the hotgraphic pop up image on desktop.",
 
@@ -227,5 +217,3 @@ Media
 Narrative
 "_classes": "items-are-full-width",
 "_comment": "Increases the width of the narrative elements to 100% in desktop view.",
-
-


### PR DESCRIPTION
Fixes: #365 

### Docs
* Removed accordion and hotgraphic item image alignment custom classes from example.json