### PR TITLE
Docs: Removed block alignment custom classes (fixes #367)

### DIFF
--- a/example.json
+++ b/example.json
@@ -90,12 +90,6 @@ blocks.json
     "_componentVerticalAlignment": "center"
 }
 
-"_classes": "align-vert-center",
-"_comment": "Aligns the blocks child components centrally on the vertical axis.",
-
-"_classes": "align-vert-bottom",
-"_comment": "Aligns child components to the bottom of the parent block on the vertical axis.",
-
 On screen animation json config
 --------------------------------------------------
 


### PR DESCRIPTION
Fixes: #367 

### Docs
* Removed block alignment custom classes from example.json
