### PR TITLE
Breaking: Quote styling rework (fixes #351)

### DIFF
--- a/less/_defaults/_font-config.less
+++ b/less/_defaults/_font-config.less
@@ -159,17 +159,19 @@
 
 // Pull quote
 // --------------------------------------------------
-@pull-quote-title-size: 1.25rem;
-@pull-quote-title-family: @title-family;
-@pull-quote-title-weight: @font-weight-regular;
-@pull-quote-title-line-height: @title-line-height;
-@pull-quote-font-style: italic;
-@pull-quote-letter-spacing: normal;
+@quote-body-size: @body-size * 1.5;
+@quote-body-family: @body-family;
+@quote-body-weight: @font-weight-regular;
+@quote-body-line-height: @body-line-height;
+@quote-body-font-style: normal;
+@quote-body-letter-spacing: normal;
 
-@pull-quote-body-size: 1rem;
-@pull-quote-body-family: @body-family;
-@pull-quote-body-weight: @font-weight-bold;
-@pull-quote-body-line-height: @body-line-height;
+@quote-attribution-size: @body-size;
+@quote-attribution-family: @body-family;
+@quote-attribution-weight: @font-weight-regular;
+@quote-attribution-line-height: @body-line-height;
+@quote-attribution-font-style: normal;
+@quote-attribution-letter-spacing: normal;
 
 // Drawer
 // --------------------------------------------------

--- a/less/_defaults/_font-mixins.less
+++ b/less/_defaults/_font-mixins.less
@@ -243,21 +243,24 @@ strong {
   letter-spacing: @item-title-letter-spacing;
 }
 
-.pull-quote-title() {
-  font-size: @pull-quote-title-size;
-  font-family: @pull-quote-title-family;
-  font-weight: @pull-quote-title-weight;
-  line-height: @pull-quote-title-line-height;
-  font-style: @pull-quote-font-style;
-  letter-spacing: @pull-quote-letter-spacing;
-  color: inherit;
+// Quote
+// --------------------------------------------------
+.quote-body() {
+  font-size: @quote-body-size;
+  font-family: @quote-body-family;
+  font-weight: @quote-body-weight;
+  line-height: @quote-body-line-height;
+  font-style: @quote-body-font-style;
+  letter-spacing: @quote-body-letter-spacing;
 }
 
-.pull-quote-body() {
-  font-size: @pull-quote-body-size;
-  font-family: @pull-quote-body-family;
-  font-weight: @pull-quote-body-weight;
-  line-height: @pull-quote-body-line-height;
+.quote-attribution() {
+  font-size: @quote-attribution-size;
+  font-family: @quote-attribution-family;
+  font-weight: @quote-attribution-weight;
+  line-height: @quote-attribution-line-height;
+  font-style: @quote-attribution-font-style;
+  letter-spacing: @quote-attribution-letter-spacing;
 }
 
 // Left over - to sort

--- a/less/core/global.less
+++ b/less/core/global.less
@@ -6,3 +6,25 @@ body {
   display: inline-block;
   vertical-align: middle;
 }
+
+// Quote related styling
+// override browser defined margins with rem unit
+blockquote,
+figure {
+  margin: @item-margin * 2;
+}
+
+// styled quote with attribution
+.figure-quote blockquote,
+.figure-quote q {
+  .quote-body;
+}
+
+.figure-quote blockquote {
+  margin: 0;
+}
+
+.figure-quote figcaption {
+  .quote-attribution;
+}
+

--- a/less/plugins/adapt-contrib-text/text.less
+++ b/less/plugins/adapt-contrib-text/text.less
@@ -1,9 +1,0 @@
-.text {
-  &.is-pull-quote &__title {
-    .pull-quote-title;
-  }
-
-  &.is-pull-quote &__body {
-    .pull-quote-body;
-  }
-}


### PR DESCRIPTION
Fixes: #351 

### Breaking
* Reworked quote styling within Adapt to provide a semantically correct approach
    * Removed `pull-quote-title` mixin
    * Removed `is-pull-quote` custom class
    * Amended `pull-quote-body` mixin to more generic `quote-body`
    * Added `quote-attribution` mixin
    * Added new variables `font-style` and `letter-spacing` to both `quote-body` and `quote-attribution`
    * Added small overrides to `blockquote` and `figure` html elements
    * Created new custom class `figure-quote` that can be used in any plugin 
