### PR TITLE
Docs: Updated readMe and example.json (fixes #345)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,82 +31,29 @@ The Adapt framework does not allow the installation of more than one theme at a 
 
 Unlike most Adapt plug-ins, the **Vanilla** theme has no attributes that are required to be configured in the course JSON files. There is, however, additional functionality available to apply background images and supporting styles for pages, articles and blocks as desired. These attributes are properly formatted as JSON in [*example.json*](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/master/example.json) and available as configurable attributes in the Adapt authoring tool.
 
-Alongside this, the [*example.json*](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/master/example.json#L86) contains a collection of custom classes that Adapt and the Vanilla theme support as standard. These classes are mostly designed to provide additional visual options to increase flexibility.
+Alongside these settings, there's a collection of [custom classes](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/Custom-Classes) that the Vanilla theme supports as standard. These classes are mostly designed to provide additional visual options to increase flexibility.
 
-The **Vanilla** theme also exposes [*colour variables*](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/master/less/_defaults/colors.less) in the Adapt authoring tool for theme editing. This feature allows you to apply and save 'preset' theme styles.
+The **Vanilla** theme also exposes [*colour variables*](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/master/less/_defaults/colors.less) in the Adapt Authoring Tool for theme-by-config editing. This feature allows you to apply and save color presets.
 
-**\_vanilla** (object): The following attributes configure the defaults for **Vanilla**. These include **\_backgroundImage**, **\_backgroundStyles** and **\_minimumHeights**. Global attributes are available at page, article and block level.
+## JSON Config and Authoring Tool Options
 
-#### Global background image
->**\_backgroundImage** (object): The backgroundImage object that contains values for **\_large**, **\_medium** and **\_small**.
+An explanation on what properties are available as part of the theme can be found [here](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/JSON-Config-and-Authoring-Tool-Options)
 
->>**\_large** (string): File name (including path) of the image used with large device width. Path should be relative to the *src* folder (e.g., *course/en/images/origami-menu-one.jpg*).
+## onScreen Animation
 
->>**\_medium** (string): File name (including path) of the image used with medium device width. Path should be relative to the *src* folder (e.g., *course/en/images/origami-menu-one.jpg*).
+Further information regarding the onScreen properties can be found on the [wiki](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/onScreen-Animation)
 
->>**\_small** (string): File name (including path) of the image used with small device width. Path should be relative to the *src* folder (e.g., *course/en/images/origami-menu-one.jpg*).
+## Custom Classes
 
-#### Global background image styles
->**_backgroundStyles** (object): Additional attributes available to customise how background images display. The backgroundStyles object contains values for **\_backgroundRepeat**, **\_backgroundSize** and **\_backgroundPosition**.
-
->>**\_backgroundRepeat** (string): This attribute defines how the background image repeats. Properties include **repeat**, **repeat-x**, **repeat-y** and **no-repeat**.
-Repeat-x: The background image is repeated only horizontally. Repeat-y: The background image is repeated only vertically.
-
->>**\_backgroundSize** (string): This attribute defines the size the background image display. Properties include **auto**, **cover**, **contain**, and **100% 100%**.
-Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container.
-
-#### Global minimum heights
->**_minimumHeights** (object): The minimum heights attribute group specifies the minimum height of the image container at different device widths (`_large`, `_medium`, and `_small`).
-
->>**\_large** (number): The minimum height should only be used in instances where the image container height needs to be greater than the content e.g. to prevent a background image being cropped.
-
->>**\_medium** (number): The minimum height should only be used in instances where the image container height needs to be greater than the content e.g. to prevent a background image being cropped.
-
->>**\_small** (number): The minimum height should only be used in instances where the image container height needs to be greater than the content e.g. to prevent a background image being cropped.
-
-#### Global responsive classes
->**\_responsiveClasses** (object): The responsive classes object adds the associated CSS class(es) to the container element at different device widths (`_large`, `_medium`, `_small`). The class(es) are removed between each device width. Useful for applying styles for a particular device width only rather than applying a global `_classes` style.
-
->>**\_large** (string): Custom CSS class that is applied at the large device width.
-
->>**\_medium** (string): Custom CSS class that is applied at the medium device width.
-
->>**\_small** (string): Custom CSS class that is applied at the small device width.
-
-#### **contentObject.json**
->**\_pageHeader** (object): The backgroundImage object that contains values for **\_large**, **\_medium** and **\_small**.
-
->>**\_large** (string): File name (including path) of the image used with large device width. Path should be relative to the *src* folder (e.g., *course/en/images/origami-menu-one.jpg*).
-
->>**\_medium** (string): File name (including path) of the image used with medium device width. Path should be relative to the *src* folder (e.g., *course/en/images/origami-menu-one.jpg*).
-
->>**\_small** (string): File name (including path) of the image used with small device width. Path should be relative to the *src* folder (e.g., *course/en/images/origami-menu-one.jpg*).
-
-#### **blocks.json**
->**\_isDividerBlock** (boolean): - Determines whether the CSS class `is-divider-block` will be applied. Acceptable values are `true` and `false`.
-
->**\_componentVerticalAlignment** (string): Defines the vertical alignment of the child component(s) in relation to the block.
-
-Visit the [**Vanilla** wiki](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki) for more information about how to use and manipulate the theme.
+All supported custom classes defined in the Vanilla theme are detailed [here](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/Custom-Classes)
 
 ## Structure
 
-| Folder/File         | Description  |
-| :-------------      |:-------------|
-| 📁 assets                     | Optional global assets can be added here |
-| 📁 fonts                      | Optional global fonts can be added here |
-| 📁 js                         | JavaScript files on which the theme depends |
-| 📁 less                       | Location of any [LESS](http://lesscss.org/) based CSS files |
-| 📁 less/_defaults             | Location of configuration LESS files |
-| 📄 less/_defaults/colors.less | Location of global colour variables |
-| 📁 less/core                  | Location of Adapt Framework LESS file styles |
-| 📁 less/plugins               | Location of Adapt plugin LESS file styles |
-| 📁 less/project               | Location of additional LESS file styles |
-| 📁 templates                  | Optional global template overrides can be added here |
+To view a breakdown of the themes structure please visit the [wiki](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/Structure)
 
-## Templates
+## Icons
 
-**Vanilla** supports customisation for the rendering of various Adapt elements through the use of [Handlebars](http://handlebarsjs.com/) templates. The file name of the template indicates the element it affects.
+The [wiki](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/Icons) features a detailed overview of the icons available within the themes custom font set
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Unlike most Adapt plug-ins, the **Vanilla** theme has no attributes that are req
 
 Alongside these settings, there's a collection of [custom classes](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/Custom-Classes) that the Vanilla theme supports as standard. These classes are mostly designed to provide additional visual options to increase flexibility.
 
-The **Vanilla** theme also exposes [*colour variables*](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/master/less/_defaults/_colors.less) in the Adapt Authoring Tool for theme-by-config editing. This feature allows you to apply and save color presets.
+The **Vanilla** theme also exposes [*color variables*](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/master/less/_defaults/_colors.less) in the Adapt Authoring Tool for theme-by-config editing. This feature allows you to apply and save color presets.
 
 ## JSON Config and Authoring Tool Options
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Unlike most Adapt plug-ins, the **Vanilla** theme has no attributes that are req
 
 Alongside these settings, there's a collection of [custom classes](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/Custom-Classes) that the Vanilla theme supports as standard. These classes are mostly designed to provide additional visual options to increase flexibility.
 
-The **Vanilla** theme also exposes [*colour variables*](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/master/less/_defaults/colors.less) in the Adapt Authoring Tool for theme-by-config editing. This feature allows you to apply and save color presets.
+The **Vanilla** theme also exposes [*colour variables*](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/master/less/_defaults/_colors.less) in the Adapt Authoring Tool for theme-by-config editing. This feature allows you to apply and save color presets.
 
 ## JSON Config and Authoring Tool Options
 

--- a/example.json
+++ b/example.json
@@ -35,9 +35,9 @@
             "_backgroundPosition": ""
         },
         "_minimumHeights": {
-            "_large": 600,
-            "_medium": 400,
-            "_small": 200
+            "_large": 0,
+            "_medium": 0,
+            "_small": 0
         }
     }
 }
@@ -84,9 +84,9 @@
         "_backgroundPosition": ""
     },
     "_minimumHeights": {
-        "_large": 600,
-        "_medium": 400,
-        "_small": 200
+        "_large": 0,
+        "_medium": 0,
+        "_small": 0
     },
     "_responsiveClasses": {
         "_large": "",
@@ -94,9 +94,9 @@
         "_small": ""
     },
     "_isDividerBlock": false,
-    "_paddingTop": "double",
-    "_paddingBottom": "half",
-    "_componentVerticalAlignment": "center"
+    "_paddingTop": "",
+    "_paddingBottom": "",
+    "_componentVerticalAlignment": ""
 }
 
 // components.json
@@ -108,11 +108,8 @@
     }
 }
 
-A detailed breakdown of each property can be found on wiki at https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/onScreen-Animation
+A detailed breakdown of each property can be found on wiki at https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/JSON-Config-and-Authoring-Tool-Options
 components.json
-
-On screen animation json config
---------------------------------------------------
 
 // onScreen Animation
 // --------------------------------------------------

--- a/example.json
+++ b/example.json
@@ -1,37 +1,33 @@
---------------------------------------------------
-JSON
---------------------------------------------------
+// Available properties
+// --------------------------------------------------
 
-Background images, styles, minimum heights, and responsive classes json config
---------------------------------------------------
-
-contentObjects.json
+// contentObjects.json
 "_vanilla": {
     "_backgroundImage": {
-        "_large": "course/en/images/example.jpg",
-        "_medium": "course/en/images/example.jpg",
-        "_small": "course/en/images/example.jpg"
+        "_large": "",
+        "_medium": "",
+        "_small": ""
     },
     "_backgroundStyles": {
-        "_backgroundSize": "contain",
-        "_backgroundRepeat": "repeat",
-        "_backgroundPosition": "center center"
+        "_backgroundSize": "",
+        "_backgroundRepeat": "",
+        "_backgroundPosition": ""
     },
     "_responsiveClasses": {
-        "_large": "class-large",
-        "_medium": "class-medium",
-        "_small": "class-small"
+        "_large": "",
+        "_medium": "",
+        "_small": ""
     },
     "_pageHeader": {
         "_backgroundImage": {
-            "_large": "course/en/images/example.jpg",
-            "_medium": "course/en/images/example.jpg",
-            "_small": "course/en/images/example.jpg"
+            "_large": "",
+            "_medium": "",
+            "_small": ""
         },
         "_backgroundStyles": {
-            "_backgroundSize": "contain",
-            "_backgroundRepeat": "repeat",
-            "_backgroundPosition": "center center"
+            "_backgroundSize": "",
+            "_backgroundRepeat": "",
+            "_backgroundPosition": ""
         },
         "_minimumHeights": {
             "_large": 600,
@@ -41,36 +37,36 @@ contentObjects.json
     }
 }
 
-articles.json
+// articles.json
 "_vanilla": {
     "_backgroundImage": {
-        "_large": "course/en/images/example.jpg",
-        "_medium": "course/en/images/example.jpg",
-        "_small": "course/en/images/example.jpg"
+        "_large": "",
+        "_medium": "",
+        "_small": ""
     },
     "_backgroundStyles": {
-        "_backgroundSize": "contain",
-        "_backgroundRepeat": "repeat",
-        "_backgroundPosition": "center center"
+        "_backgroundSize": "",
+        "_backgroundRepeat": "",
+        "_backgroundPosition": ""
     },
     "_responsiveClasses": {
-        "_large": "class-large",
-        "_medium": "class-medium",
-        "_small": "class-small"
+        "_large": "",
+        "_medium": "",
+        "_small": ""
     }
 }
 
-blocks.json
+// blocks.json
 "_vanilla": {
     "_backgroundImage": {
-        "_large": "course/en/images/example.jpg",
-        "_medium": "course/en/images/example.jpg",
-        "_small": "course/en/images/example.jpg"
+        "_large": "",
+        "_medium": "",
+        "_small": ""
     },
     "_backgroundStyles": {
-        "_backgroundSize": "contain",
-        "_backgroundRepeat": "repeat",
-        "_backgroundPosition": "center center"
+        "_backgroundSize": "",
+        "_backgroundRepeat": "",
+        "_backgroundPosition": ""
     },
     "_minimumHeights": {
         "_large": 600,
@@ -78,136 +74,27 @@ blocks.json
         "_small": 200
     },
     "_responsiveClasses": {
-        "_large": "class-large",
-        "_medium": "class-medium",
-        "_small": "class-small"
+        "_large": "",
+        "_medium": "",
+        "_small": ""
     },
-    // Divider Block - adds class to `.block` element
     "_isDividerBlock": false,
-    // Defines the vertical alignment of the child component(s) in relation to the block.
-    // Top: Aligns descendents to the top of the block. Center: Aligns descendents to the center of the block. Bottom: Aligns descendents to the bottom of the block.
-    // The default alignment is `top`.
     "_componentVerticalAlignment": "center"
 }
 
-On screen animation json config
---------------------------------------------------
+A detailed breakdown of each property can be found on wiki at https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/onScreen-Animation
 
-blocks.json / components.json
+// onScreen Animation
+// --------------------------------------------------
 "_onScreen": {
-    "_isEnabled": true,
-    "_comment": "Supported classes = 'fade-in' | 'fade-in-left' | 'fade-in-right' | 'fade-in-top' | 'fade-in-bottom'. Additional classes can be used but they must be predefined in one of the Less files",
-    "_classes": "fade-in-bottom",
-    "_percentInviewVertical": 50
+  "_isEnabled": true,
+  "_classes": "fade-in",
+  "_percentInviewVertical": 50
 }
 
---------------------------------------------------
-Classes
---------------------------------------------------
+Further information regarding onScreen animation can be found on the wiki at https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/onScreen-Animation
 
-Common classes
---------------------------------------------------
-"_classes": "bg-color",
-"_comment": "Sets up the solid background colour mixin. Combine with one of the following classes e.g. 'bg-color black'. Note: the following class must be a predefined variable. Mixin can be extended to include custom colours.",
+// Vanilla Custom Classes
+// --------------------------------------------------
 
-"_classes": "transparent-light",
-"_comment": "Sets the background colour of the block to transparent and changes the font colour to black. Useful for displaying text over a light background image.",
-
-"_classes": "transparent-dark",
-"_comment": "Sets the background colour of the block to transparent and changes the font colour to white. Useful for displaying text over a dark background image.",
-
-"_classes": "black",
-"_comment": "Sets the background colour of the block to black and changes the font colour to white.",
-
-"_classes": "background",
-"_comment": "Sets the background colour of the block to use the variable @background (default is black) and changes the font colour to use the variable @background-inverted (default is white). These variables can be changed in the ‘_colors.less’ file.",
-
-Content Object classes
---------------------------------------------------
-
-"_htmlClasses": "hide-nav-back-btn",
-"_comment": "Hides the navigation back button on the page.",
-
-"_classes": "hide-page-header",
-"_comment": "Hides the page header on the page.",
-
-"_classes": "header-color",
-"_comment": "Sets up the header solid background colour mixin. Combine with one of the following classes e.g. 'header-color background'. Note: the following class must be a predefined variable. Mixin can be extended to include client colours. Can be set for menu and/or page header.",
-
-"_classes": "transparent-light",
-"_comment": "Sets the background colour of the header to transparent and changes the font colour to @font-color. Useful for displaying text over a light background image.",
-
-"_classes": "transparent-dark",
-"_comment": "Sets the background colour of the header to transparent and changes the font colour to @font-color-inverted. Useful for displaying text over a dark background image.",
-
-"_classes": "background",
-"_comment": "Sets the background colour of the header to use the variable @background (default is black) and changes the font colour to use the variable @background-inverted (default is white). These variables can be changed in the ‘_colors.less’ file.",
-
-Block classes
---------------------------------------------------
-
-"_classes": "reverse-desktop-order",
-"_comment": "Reverses the visual layout of the components above the medium breakpoint (default is 760px). e.g. Left layout components would still render first in the DOM order but visually appear on the right-hand side above the medium breakpoint. The components would vertically stack as per the DOM order below the breakpoint.",
-
-"_classes": "extend-content-container",
-"_comment": "Extend width of block to 70rem (default is 1120px).",
-
-"_classes": "extend-container",
-"_comment": "Extend width of block to max page width (default is 1440px).",
-
-"_classes": "remove-padding-top | remove-top-padding",
-"_comment": "Removes the top padding from block.",
-
-"_classes": "remove-padding-bottom | remove-bottom-padding",
-"_comment": "Removes the bottom padding from block.",
-
-"_classes": "reduce-padding-top",
-"_comment": "Reduce the blocks top padding by half.",
-
-"_classes": "reduce-padding-bottom",
-"_comment": "Reduce the blocks bottom padding by half.",
-
-"_classes": "increase-padding-top",
-"_comment": "Double the blocks top padding.",
-
-"_classes": "increase-padding-bottom",
-"_comment": "Double the blocks bottom padding.",
-
-Component classes
---------------------------------------------------
-
-Columns
-Breakpoints are assigned from the smallest screen resolution to the widest until they reach the max width value. Multiple column classes can be defined on a singular component to change the layout responsively. The column number assigned to a component is configurable and can be any number between 1 and 12. It is advisable to not exceed a combined total of 12 columns for all components within a block for each breakpoint.
-
-"_classes": "col-xs-8",
-"_comment": "On screens ranging from 0px to 520px the component fills 8 out of the 12 columns available.",
-
-"_classes": "col-sm-8",
-"_comment": "On screens ranging from 520px to 760px the component fills 8 out of the 12 columns available.",
-
-"_classes": "col-md-8",
-"_comment": "On screens ranging from 760px to 900px the component fills 8 out of the 12 columns available.",
-
-"_classes": "col-lg-8",
-"_comment": "On screens ranging from 900px to 1440px the component fills 8 out of the 12 columns available.",
-
-"_classes": "col-xl-8",
-"_comment": "On screens above 1440px the component fills 8 out of the 12 columns available.",
-
-Hotgraphic item
-"_classes": "hide-desktop-image",
-"_comment": "Hide the hotgraphic pop up image on desktop.",
-
-"_classes": "hide-popup-image",
-"_comment": "Hide the hotgraphic pop up image for all screen sizes.",
-
-Media
-"_classes": "invert-play-icon",
-"_comment": "Inverts the media player play icon from white to black.",
-
-"_classes": "offset-media-controls",
-"_comment": "Offset control bar to display underneath the video element instead of overlaid. Useful for videos which contain subtitles or text within the bottom area of the video frame.",
-
-Narrative
-"_classes": "items-are-full-width",
-"_comment": "Increases the width of the narrative elements to 100% in desktop view.",
+All supported custom classes defined in the Vanilla theme can be found on the wiki at https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/Custom-Classes

--- a/example.json
+++ b/example.json
@@ -20,9 +20,9 @@
     },
     "_pageHeader": {
         "_textAlignment": {
-            "_title": "left",
-            "_body": "center",
-            "_instruction": "right"
+            "_title": "",
+            "_body": "",
+            "_instruction": ""
         },
         "_backgroundImage": {
             "_large": "",
@@ -45,9 +45,9 @@
 // articles.json
 "_vanilla": {
     "_textAlignment": {
-        "_title": "left",
-        "_body": "center",
-        "_instruction": "right"
+        "_title": "",
+        "_body": "",
+        "_instruction": ""
     },
     "_backgroundImage": {
         "_large": "",
@@ -69,9 +69,9 @@
 // blocks.json
 "_vanilla": {
     "_textAlignment": {
-        "_title": "left",
-        "_body": "center",
-        "_instruction": "right"
+        "_title": "",
+        "_body": "",
+        "_instruction": ""
     },
     "_backgroundImage": {
         "_large": "",
@@ -97,6 +97,15 @@
     "_paddingTop": "double",
     "_paddingBottom": "half",
     "_componentVerticalAlignment": "center"
+}
+
+// components.json
+"_vanilla": {
+    "_textAlignment": {
+        "_title": "",
+        "_body": "",
+        "_instruction": ""
+    }
 }
 
 A detailed breakdown of each property can be found on wiki at https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/onScreen-Animation


### PR DESCRIPTION
Fixes: #345 

### Docs
* Updates to readme and example.json files 
    * Moved json property explanations from readme and example.json to the [wiki](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/JSON-Config-and-Authoring-Tool-Options)
    * Moved onScreen animation information from example.json to the [wiki](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/onScreen-Animation)
    * Moved custom classes breakdown from example.json to the [wiki](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/Custom-Classes) 
