### PR TITLE
Fix: Added missing header-color default (fixes: #372)

### DIFF
--- a/less/project/theme-extras.less
+++ b/less/project/theme-extras.less
@@ -21,6 +21,7 @@
 // e.g. 'header-color transparent-dark'
 // Note: both arguments must be predefined variables
 // --------------------------------------------------
+.header-color-mixin(black, white);
 .header-color-mixin(background, background-inverted);
 .header-color-mixin(transparent-light, font-color);
 .header-color-mixin(transparent-dark, font-color-inverted);


### PR DESCRIPTION
Fixes: #372 

### Fix
* Add missing default `black` value for `header-color` mixin
