### PR TITLE
Update: Extend columns to support menu item widths (fixes #383)

### DIFF
--- a/less/project/columns.less
+++ b/less/project/columns.less
@@ -1,5 +1,8 @@
 .make-columns(@size, @media-query, @count, @iteration: 1) when (@count >= @iteration) {
   @media (min-width: @media-query) {
+    .boxmenu-item.col-@{size}-@{iteration} {
+      width: (@iteration * 100% / @count);
+    }
     .component.col-@{size}-@{iteration} {
       width: (@iteration * 100% / @count);
     }


### PR DESCRIPTION
Extend the existing columns style to include Boxmenu items to give us more flexibility with Boxmenu without the need for custom themes/CSS.

See issue for detail https://github.com/adaptlearning/adapt-contrib-vanilla/issues/383

Note, as we are no longer documenting custom classes within Vanilla the [Wiki page ](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/Custom-Classes#columns)will need updating to reflect this PR once merged. I've included the existing documentation below and boldened any edits if you could review with this PR please.

_Breakpoints are assigned from the smallest screen resolution to the widest until they reach the max **content** width value. Multiple column classes with different breakpoint selectors can be defined on a singular **menu item (contentObject)** or component to change the layout responsively. The column number assigned to a **menu item/component** is configurable and can be any number between 1 and 12 with 12 equaling full width. The application of columns overrides the **component** `_layout` (Framework) and left / right / full width (Authoring Tool) configuration. It is advisable for beginners not to exceed a combined total of 12 columns for all components within a block for each breakpoint._*

*We'll also need to update the tables to replace reference to **component** with **menu item/component**.


