### PR TITLE
update margins on menu-body and menu-instruction

### DIFF
--- a/less/_defaults/_spacing-config.less
+++ b/less/_defaults/_spacing-config.less
@@ -20,8 +20,8 @@
 // --------------------------------------------------
 @menu-title-margin: 1rem;
 @menu-subtitle-margin: 1rem;
-@menu-body-margin: 0;
-@menu-instruction-margin: 0;
+@menu-body-margin: 1rem;
+@menu-instruction-margin: 1rem;
 
 // Menu item text margin
 // --------------------------------------------------


### PR DESCRIPTION
Fix: values of menu variables are inconsistent with similar elements
fixes #387

* @menu-body-margin changed from '0' to '1rem'
* @menu-instruction-margin changed from '0' to '1rem'


