### PR TITLE
New: Added favicon support (fixes #306)

### DIFF
--- a/example.json
+++ b/example.json
@@ -1,6 +1,13 @@
 // Available properties
 // --------------------------------------------------
 
+// course.json
+"_vanilla": {
+    "_favIcon": {
+        "_src": "course/en/images/cropped-nav_logo_gold-192x192.png"
+    }
+},
+
 // contentObjects.json
 "_vanilla": {
     "_backgroundImage": {

--- a/example.json
+++ b/example.json
@@ -4,7 +4,7 @@
 // course.json
 "_vanilla": {
     "_favIcon": {
-        "_src": "course/en/images/cropped-nav_logo_gold-192x192.png"
+        "_src": ""
     }
 },
 

--- a/js/theme.js
+++ b/js/theme.js
@@ -22,8 +22,11 @@ class Theme extends Backbone.Controller {
   addFavIcon() {
     const theme = Adapt.course.get('_vanilla');
     if (!theme._favIcon._src) return;
-    const $link = $(`<link rel="icon" href="${theme._favIcon._src}" size="192x192" />`);
-    $('head').append($link);
+    const $linkStandard = $(`<link rel="icon" href="${theme._favIcon._src}" size="192x192" />`);
+    const $linkApple = $(`<link rel="apple-touch-icon" href="${theme._favIcon._src}" />`);
+    $('head')
+      .append($linkStandard)
+      .append($linkApple);
   }
 
   onPostRender(view) {

--- a/js/theme.js
+++ b/js/theme.js
@@ -16,6 +16,14 @@ class Theme extends Backbone.Controller {
 
   onDataReady() {
     $('html').addClass(Adapt.course.get('_courseStyle'));
+    this.addFavIcon();
+  }
+
+  addFavIcon() {
+    const theme = Adapt.course.get('_vanilla');
+    if (!theme._favIcon._src) return;
+    const $link = $(`<link rel="icon" href="${theme._favIcon._src}" size="192x192" />`);
+    $('head').append($link);
   }
 
   onPostRender(view) {

--- a/properties.schema
+++ b/properties.schema
@@ -698,7 +698,29 @@
           "type": "object"
         },
         "course": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "_vanilla": {
+              "type": "object",
+              "required": false,
+              "properties": {
+                "_favIcon": {
+                  "type": "object",
+                  "required": false,
+                  "legend": "FavIcon",
+                  "properties": {
+                    "_src": {
+                      "type": "string",
+                      "required": true,
+                      "default": "",
+                      "inputType": "Asset:image",
+                      "validators": ["required"]
+                    }
+                  }
+                }
+              }
+            }
+          }
         },
         "contentobject": {
           "type": "object",

--- a/properties.schema
+++ b/properties.schema
@@ -712,10 +712,10 @@
                     "_src": {
                       "type": "string",
                       "required": false,
-                      "default": "https://www.adaptlearning.org/wp-content/uploads/2018/02/cropped-nav_logo_gold-192x192.png",
+                      "default": "",
                       "inputType": "Asset:image",
                       "validators": [],
-                      "help": "Select a project favicon to improve user experience and enforce brand consistency. This will be displayed in places like your browser's address bar, page tabs and bookmarks menu. Usually, a favicon is 16 x 16 pixels in size and stored in the GIF, PNG, or ICO file format."
+                      "help": "Select a favicon to improve user experience and enforce brand consistency. This will be displayed in places like your browser's address bar, page tabs and bookmarks menu. Usually, a favicon is 16 x 16 pixels in size and stored in the GIF, PNG, or ICO file format."
                     }
                   }
                 }

--- a/properties.schema
+++ b/properties.schema
@@ -711,10 +711,11 @@
                   "properties": {
                     "_src": {
                       "type": "string",
-                      "required": true,
-                      "default": "",
+                      "required": false,
+                      "default": "https://www.adaptlearning.org/wp-content/uploads/2018/02/cropped-nav_logo_gold-192x192.png",
                       "inputType": "Asset:image",
-                      "validators": ["required"]
+                      "validators": [],
+                      "help": "Select a project favicon to improve user experience and enforce brand consistency. This will be displayed in places like your browser's address bar, page tabs and bookmarks menu. Usually, a favicon is 16 x 16 pixels in size and stored in the GIF, PNG, or ICO file format."
                     }
                   }
                 }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -1,0 +1,36 @@
+{
+  "$anchor": "graphic-course",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "$patch": {
+    "source": {
+      "$ref": "course"
+    },
+    "with": {
+      "properties": {
+        "_vanilla": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "_favIcon": {
+              "type": "object",
+              "default": {},
+              "title": "FavIcon",
+              "properties": {
+                "_src": {
+                  "type": "string",
+                  "isObjectId": true,
+                  "title": "Image",
+                  "_backboneForms": {
+                    "type": "Asset",
+                    "media": "image"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -21,6 +21,8 @@
                   "type": "string",
                   "isObjectId": true,
                   "title": "Image",
+                  "description": "Select a project favicon to improve user experience and enforce brand consistency. This will be displayed in places like your browser's address bar, page tabs and bookmarks menu. Usually, a favicon is 16 x 16 pixels in size and stored in the GIF, PNG, or ICO file format.",
+                  "default": "https://www.adaptlearning.org/wp-content/uploads/2018/02/cropped-nav_logo_gold-192x192.png",
                   "_backboneForms": {
                     "type": "Asset",
                     "media": "image"

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -1,5 +1,5 @@
 {
-  "$anchor": "graphic-course",
+  "$anchor": "vanilla-course",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "$patch": {
@@ -10,19 +10,20 @@
       "properties": {
         "_vanilla": {
           "type": "object",
+          "title": "Theme",
           "default": {},
           "properties": {
             "_favIcon": {
               "type": "object",
               "default": {},
-              "title": "FavIcon",
+              "title": "Favicon",
               "properties": {
                 "_src": {
                   "type": "string",
                   "isObjectId": true,
                   "title": "Image",
-                  "description": "Select a project favicon to improve user experience and enforce brand consistency. This will be displayed in places like your browser's address bar, page tabs and bookmarks menu. Usually, a favicon is 16 x 16 pixels in size and stored in the GIF, PNG, or ICO file format.",
-                  "default": "https://www.adaptlearning.org/wp-content/uploads/2018/02/cropped-nav_logo_gold-192x192.png",
+                  "description": "Select a favicon to improve user experience and enforce brand consistency. This will be displayed in places like your browser's address bar, page tabs and bookmarks menu. Usually, a favicon is 16 x 16 pixels in size and stored in the GIF, PNG, or ICO file format.",
+                  "default": "",
                   "_backboneForms": {
                     "type": "Asset",
                     "media": "image"


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt-contrib-core/issues/306

### New
* Added favicon support

### Example icon
Source url: https://www.adaptlearning.org/wp-content/uploads/2018/02/cropped-nav_logo_gold-192x192.png
Zip: [cropped-nav_logo_gold-192x192.zip](https://github.com/adaptlearning/adapt-contrib-vanilla/files/10863945/cropped-nav_logo_gold-192x192.zip)


### References
* https://en.wikipedia.org/wiki/Favicon
* https://developer.mozilla.org/en-US/docs/Glossary/Favicon
* https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#icon
* https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html#//apple_ref/doc/uid/TP40002051-CH3-SW4
