### PR TITLE
#398 Remove hover states from progress indicators

### DIFF
--- a/less/plugins/adapt-contrib-narrative/narrative.less
+++ b/less/plugins/adapt-contrib-narrative/narrative.less
@@ -22,11 +22,6 @@
   &__progress {
     background-color: @item-color;
     border-radius: 50%;
-
-    .no-touch &:not(.is-selected):hover {
-      background-color: @item-color-hover;
-      .transition(background-color @duration ease-in);
-    }
   }
 
   &__progress.is-visited {


### PR DESCRIPTION
Fixes #398 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Removes hover states from progress indicators

### Dependencies
https://github.com/adaptlearning/adapt-contrib-narrative/pull/250


