### PR TITLE
Fix: Make align-vert-center work with block min-heights (fixes #403)

### DIFF
--- a/less/core/block.less
+++ b/less/core/block.less
@@ -50,7 +50,15 @@
   &.remove-padding-bottom &__inner { padding-bottom: 0; }
 
   // Aligns child components centrally on the vertical axis
-  &.align-vert-center .component__container { align-items: center; }
+  &.align-vert-center {
+    .block__inner,
+    .component__container {
+      min-height: inherit;
+    }
+    .component__container {
+      align-items: center;
+    }
+  }
 
   // Aligns child components to the bottom of the parent block on the vertical axis
   &.align-vert-bottom .component__container {align-items: flex-end; }


### PR DESCRIPTION
Fixes #403 

### Fix
* `align-vert-center` class: Adds `min-height: inherit` to `.block__inner` and `.component__container`. This ensures components are vertically centered when using a minimum height on a block. 

### Testing
Add the following config to a block that contains "short" component(s) like a Text component with minimal text:
```
    "_vanilla": {
      "_minimumHeights": {
        "_large": 600,
        "_medium": 600,
        "_small": 200
      },
      "_componentVerticalAlignment": "center"
    }
```
The result should be that the component inside the block is vertically centered.