### PR TITLE
Replace glossary search textbox margin with padding

### DIFF
--- a/less/plugins/adapt-contrib-glossary/glossary.less
+++ b/less/plugins/adapt-contrib-glossary/glossary.less
@@ -1,6 +1,6 @@
 .glossary {
   &__textbox-container {
-    margin: (@item-margin * 2) (@item-margin * 2) 0;
+    padding: @item-padding;
   }
 
   &__textbox {
@@ -8,7 +8,7 @@
   }
 
   &__checkbox-container {
-    padding: @item-padding;
+    padding: 0 @item-padding @item-padding;
   }
 
   &__checkbox-input,


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-glossary/pull/69

Replace `.glossary__textbox-container` `margin` with `padding` to prevent search box shifting up when scrolled (see screenshots of issue).

![margin](https://user-images.githubusercontent.com/7045330/227267254-88510f71-667f-4e66-8d5a-5118857a2dcc.png)
When scrolled:
![margin_on_scroll](https://user-images.githubusercontent.com/7045330/227267281-d3c18a2b-a715-40a5-8ed9-15a9fcbc3015.png)


