### PR TITLE
Fix: Fill styling (fixes #410)

### DIFF
--- a/less/plugins/adapt-contrib-confidenceSlider/confidenceSlider.less
+++ b/less/plugins/adapt-contrib-confidenceSlider/confidenceSlider.less
@@ -1,5 +1,7 @@
 .confidenceslider {
-  &__fill-linked {
-    background-color: @item-color-selected;
+  .slider {
+    &__item-input-fill-linked {
+      background-color: @item-color;
+    }
   }
 }


### PR DESCRIPTION
Fixes: #410 

### Fix
* Adjusted selectors to resolve linked fill styling

### Dependencies 
* https://github.com/adaptlearning/adapt-contrib-slider/pull/183
* https://github.com/adaptlearning/adapt-contrib-confidenceSlider/pull/97
