### PR TITLE
Fix: Add font size variable for nav button label (fixes #414)

### DIFF
--- a/less/_defaults/_font-config.less
+++ b/less/_defaults/_font-config.less
@@ -54,6 +54,10 @@
 @link-weight: @font-weight-regular;
 @link-line-height: @body-line-height;
 
+// Navigation
+// --------------------------------------------------
+@nav-btn-label-size: 0.875rem;
+
 // Menu header
 // --------------------------------------------------
 @menu-title-size: 3rem;

--- a/less/core/nav.less
+++ b/less/core/nav.less
@@ -15,4 +15,8 @@
       .transition(background-color @duration ease-in, color @duration ease-in;);
     }
   }
+
+  &__btn-label {
+    font-size: @nav-btn-label-size;
+  }
 }


### PR DESCRIPTION
Fixes #414 

### Fix
* Adds new variable `@nav-btn-label-size` for the nav button label font size.

### Steps for testing
1. Switch core to `issue/338`
2. In course.json, enable nav labels with:

```
  "_navigation": {
    "_showLabel": true
  },
```
3. Adjust `@nav-btn-label-size` in your theme and see it reflected in the nav button label text.

### Requires
* Core: https://github.com/adaptlearning/adapt-contrib-core/pull/339
