### PR TITLE
Fix: Add new menu header color variables (fixes #402)

### DIFF
--- a/less/_defaults/_colors.less
+++ b/less/_defaults/_colors.less
@@ -87,6 +87,11 @@
 
 // Menu
 // --------------------------------------------------
+@menu-header-background-color: transparent;
+@menu-header-title-color: @heading-color;
+@menu-header-body-color: @font-color;
+@menu-header-instruction-color: @font-color;
+
 @menu-item: @white;
 @menu-item-inverted: @font-color;
 @menu-item-border-color: @item-color;

--- a/less/plugins/adapt-contrib-boxmenu/boxMenu.less
+++ b/less/plugins/adapt-contrib-boxmenu/boxMenu.less
@@ -36,12 +36,13 @@
   &__header-inner {
     position: relative;
     .l-container-padding(@menu-header-padding-ver, @menu-header-padding-hoz);
+    background-color: @menu-header-background-color;
   }
 
   &__title {
     margin-bottom: @menu-title-margin;
     .menu-title;
-    color: @heading-color;
+    color: @menu-header-title-color;
   }
 
   &__subtitle {
@@ -52,11 +53,13 @@
   &__body {
     margin-bottom: @menu-body-margin;
     .menu-body;
+    color: @menu-header-body-color;
   }
 
   &__instruction {
     margin-bottom: @menu-instruction-margin;
     .menu-instruction;
+    color: @menu-header-instruction-color;
   }
 
   &__body a,

--- a/properties.schema
+++ b/properties.schema
@@ -275,6 +275,30 @@
         "required": false,
         "title": "Menu",
         "properties": {
+          "menu-header-background-color": {
+            "title": "Menu header background colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": ""
+          },
+          "menu-header-title-color": {
+            "title": "Menu header title colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": ""
+          },
+          "menu-header-body-color": {
+            "title": "Menu header body colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": ""
+          },
+          "menu-header-instruction-color": {
+            "title": "Menu header instruction colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": ""
+          },
           "menu-item": {
             "title": "Menu item colour",
             "type": "string",

--- a/schema/theme.schema.json
+++ b/schema/theme.schema.json
@@ -267,6 +267,30 @@
       "title": "Menu",
       "default": {},
       "properties": {
+        "menu-header-background-color": {
+          "type": "string",
+          "title": "Menu header background colour",
+          "default": "",
+          "_backboneForms": "ColourPicker"
+        },
+        "menu-header-title-color": {
+          "type": "string",
+          "title": "Menu header title colour",
+          "default": "",
+          "_backboneForms": "ColourPicker"
+        },
+        "menu-header-body-color": {
+          "type": "string",
+          "title": "Menu header body colour",
+          "default": "",
+          "_backboneForms": "ColourPicker"
+        },
+        "menu-header-instruction-color": {
+          "type": "string",
+          "title": "Menu header instruction colour",
+          "default": "",
+          "_backboneForms": "ColourPicker"
+        },
         "menu-item": {
           "type": "string",
           "title": "Menu item colour",


### PR DESCRIPTION
Fixes #402 

### Fix
* Adds new color variables for the menu header: `@menu-header-background-color`, `@menu-header-title-color`, `@menu-header-body-color`, and `@menu-header-instruction-color`
* Updates schemas
