### PR TITLE
Fix: Add @shadow-opacity variable (fixes #424)

### DIFF
--- a/less/_defaults/_colors.less
+++ b/less/_defaults/_colors.less
@@ -189,3 +189,4 @@
 // --------------------------------------------------
 @shadow: @black;
 @shadow-inverted: @white;
+@shadow-opacity: 50%;

--- a/less/core/loading.less
+++ b/less/core/loading.less
@@ -1,7 +1,7 @@
 @loading-anim-delay: 0.16s;
 
 .loading {
-  background-color: fade(@shadow, 50%);
+  background-color: fade(@shadow, @shadow-opacity);
   color: @shadow-inverted;
 
   &__inner,

--- a/less/core/shadow.less
+++ b/less/core/shadow.less
@@ -1,3 +1,3 @@
 .shadow {
-  background-color: fade(@shadow, 50%);
+  background-color: fade(@shadow, @shadow-opacity);
 }


### PR DESCRIPTION
Fix #424 

### Fix
* Adds `@shadow-opacity` Less variable to control the opacity of the shadow overlay. This will be visible behind Notify popups and on the loading screen.