### PR TITLE
Fix: set .drawer color (fixes #433)

### DIFF
--- a/less/core/drawer.less
+++ b/less/core/drawer.less
@@ -1,5 +1,6 @@
 .drawer {
   background-color: @drawer;
+  color: @drawer-inverted;
 
   &__toolbar {
     border-bottom: 1px solid @drawer-item-hover;


### PR DESCRIPTION
In [drawer.less](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/aac3a2bdade9398bc9cf353dd40b64f5235096dd/less/core/drawer.less#L2), `.drawer` has a `background-color` defined but no `color`. Instead the `color` is inherited from `body`. 

I'd expect `.drawer` to use `color: @drawer-inverted`. Typically all Adapt elements use the named variable for `background-color` and the invert for `color`. For example:

```
.notify__popup {
    background-color: @notify;
    color: @notify-inverted;
}
```

Fixes #433 