### PR TITLE
Fix: Convert the default instruction text styling from italics to bold

### DIFF
--- a/less/_defaults/_font-config.less
+++ b/less/_defaults/_font-config.less
@@ -120,9 +120,9 @@
 @page-body-line-height: @body-line-height;
 
 @page-instruction-size: @page-body-size;
-@page-instruction-family: @body-family;
+@page-instruction-family: @page-body-family;
 @page-instruction-weight: @instruction-weight;
-@page-instruction-line-height: @body-line-height;
+@page-instruction-line-height: @page-body-line-height;
 @page-instruction-font-style: @instruction-font-style;
 
 // Page

--- a/less/_defaults/_font-config.less
+++ b/less/_defaults/_font-config.less
@@ -37,9 +37,9 @@
 
 @instruction-size: @body-size;
 @instruction-family: @body-family;
-@instruction-weight: @font-weight-regular;
+@instruction-weight: @font-weight-bold;
 @instruction-line-height: @body-line-height;
-@instruction-font-style: italic;
+@instruction-font-style: normal;
 
 @btn-size: @body-size;
 @btn-weight: @font-weight-regular;
@@ -80,9 +80,9 @@
 @menu-body-line-height: @body-line-height;
 
 @menu-instruction-size: @menu-body-size;
-@menu-instruction-family: @body-family;
-@menu-instruction-weight: @font-weight-regular;
-@menu-instruction-line-height: @body-line-height;
+@menu-instruction-family: @menu-body-family;
+@menu-instruction-weight: @instruction-weight;
+@menu-instruction-line-height: @menu-body-line-height;
 @menu-instruction-font-style: @instruction-font-style;
 
 // Menu item
@@ -121,7 +121,7 @@
 
 @page-instruction-size: @page-body-size;
 @page-instruction-family: @body-family;
-@page-instruction-weight: @font-weight-regular;
+@page-instruction-weight: @instruction-weight;
 @page-instruction-line-height: @body-line-height;
 @page-instruction-font-style: @instruction-font-style;
 


### PR DESCRIPTION
Update instruction styling to 'normal' and weight to 'bold'. Update variables in menu & page header

Fixes: #395 

