### PR TITLE
@navigation-height deprecated, added notes to avoid confusion

### DIFF
--- a/less/_defaults/_spacing-containers.less
+++ b/less/_defaults/_spacing-containers.less
@@ -11,6 +11,8 @@
 
 // Navigation height
 // --------------------------------------------------
+// Deprecated @navigation-height: Navigation height is now set
+// by --adapt-navigation-height and is updated by JS
 @navigation-height: @icon-size + (@icon-padding * 2);
 
 // Menu container and header padding


### PR DESCRIPTION
Added some notes to @navigation-height variable in theme to avoid confusion as this has now been deprecated in favour of an adapt css variable