### PR TITLE
Update: replace notify button icon duplicate styles with mixin (fixes #443)

### DIFF
--- a/less/core/notify.less
+++ b/less/core/notify.less
@@ -72,17 +72,7 @@
   }
 
   &__btn-icon {
-    margin: @btn-margin / 2;
-    padding: @btn-padding / 2;
-    background-color: @notify-icon;
-    color: @notify-icon-inverted;
-    border-radius: 50%;
-
-    .no-touch &:not(.is-disabled):not(.is-locked):hover {
-      background-color: @notify-icon-hover;
-      color: @notify-icon-inverted-hover;
-      .transition(background-color @duration ease-in, color @duration ease-in;);
-    }
+    .notify-btn-icon;
   }
 
   &__close-btn {
@@ -108,4 +98,20 @@
   //     left: 0;
   //   }
   // }
+}
+
+// Global Notify button icon
+// --------------------------------------------------
+.notify-btn-icon() {
+  margin: @btn-margin / 2;
+  padding: @btn-padding / 2;
+  background-color: @notify-icon;
+  color: @notify-icon-inverted;
+  border-radius: 50%;
+
+  .no-touch &:not(.is-disabled):not(.is-locked):hover {
+    background-color: @notify-icon-hover;
+    color: @notify-icon-inverted-hover;
+    .transition(background-color @duration ease-in, color @duration ease-in;);
+  }
 }

--- a/less/core/notifyPush.less
+++ b/less/core/notifyPush.less
@@ -37,17 +37,7 @@
     position: absolute;
     top: 0;
     right: 0;
-    margin: @btn-margin / 2;
-    padding: @btn-padding / 2;
-    background-color: @notify-icon;
-    color: @notify-icon-inverted;
-    border-radius: 50%;
-
-    .no-touch &:not(.is-disabled):not(.is-locked):hover {
-      background-color: @notify-icon-hover;
-      color: @notify-icon-inverted-hover;
-      .transition(background-color @duration ease-in, color @duration ease-in;);
-    }
+    .notify-btn-icon;
 
     .dir-rtl & {
       right: auto;

--- a/less/plugins/adapt-contrib-hotgraphic/hotgraphicPopup.less
+++ b/less/plugins/adapt-contrib-hotgraphic/hotgraphicPopup.less
@@ -8,17 +8,7 @@
 
   &__controls,
   &__close {
-    margin: @btn-margin / 2;
-    padding: @btn-padding / 2;
-    background-color: @notify-icon;
-    color: @notify-icon-inverted;
-    border-radius: 50%;
-
-    .no-touch &:not(.is-disabled):not(.is-locked):hover {
-      background-color: @notify-icon-hover;
-      color: @notify-icon-inverted-hover;
-      .transition(background-color @duration ease-in, color @duration ease-in;);
-    }
+    .notify-btn-icon;
   }
 
   &__item-title {

--- a/less/plugins/adapt-contrib-tutor/tutor.less
+++ b/less/plugins/adapt-contrib-tutor/tutor.less
@@ -18,17 +18,7 @@
   }
 
   &__btn-icon {
-    margin: @btn-margin / 2;
-    padding: @btn-padding / 2;
-    background-color: @notify-icon;
-    color: @notify-icon-inverted;
-    border-radius: 50%;
-
-    .no-touch &:not(.is-disabled):not(.is-locked):hover {
-      background-color: @notify-icon-hover;
-      color: @notify-icon-inverted-hover;
-      .transition(background-color @duration ease-in, color @duration ease-in;);
-    }
+    .notify-btn-icon;
   }
 
   // overlay


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-vanilla/issues/443

The default style for Notify icon buttons is consistent across all plugins however the styles are duplicated across the various plugin LESS files.

Vanilla instances include:
- Notify popup and Notify push
- Hotgraphic popup
- Tutor popup

This PR wraps the existing icon button styles within a mixin and applies the mixin in the various plugin LESS files to replace duplicated code.

As the mixin is specific to Notify, the mixin remains in notify.less.