### PR TITLE
Fix: Add margins for mobile stacked layout (fixes #450)

### DIFF
--- a/less/plugins/adapt-contrib-narrative/narrative.less
+++ b/less/plugins/adapt-contrib-narrative/narrative.less
@@ -82,10 +82,10 @@
   }
 
   // mobile stacked layout
-  &__widget.is-stacked &__content-item {
+  &__inner.is-stacked &__content-item {
     margin-bottom: (@item-margin * 4);
   }
-  &__widget.is-stacked &__content-image {
+  &__inner.is-stacked &__content-image {
     margin-bottom: @item-title-margin;
   }
 }

--- a/less/plugins/adapt-contrib-narrative/narrative.less
+++ b/less/plugins/adapt-contrib-narrative/narrative.less
@@ -80,4 +80,12 @@
   &.has-img-zoom &__slider-image-container {
     .img-zoom();
   }
+
+  // mobile stacked layout
+  &__widget.is-stacked &__content-item {
+    margin-bottom: (@item-margin * 4);
+  }
+  &__widget.is-stacked &__content-image {
+    margin-bottom: @item-title-margin;
+  }
 }


### PR DESCRIPTION
Fix #450

### Fix
When using the new mobile stacked layout:
* Adds spacing between Narrative items
* Adds spacing between Narrative item graphic and title

### Considerations
Are there better variables to use here? Or should we create new variables? My goal was to create enough spacing between items to clearly delineate each one.
```
&__widget.is-stacked &__content-item {
  margin-bottom: (@item-margin * 4);
}
&__widget.is-stacked &__content-image {
  margin-bottom: @item-title-margin;
}
```

### Dependencies
Requires Narrative PR:
https://github.com/adaptlearning/adapt-contrib-narrative/pull/270