### PR TITLE
Fix: Remove background color on Hot Graphic pins when using pin images (fixes #453)

### DIFF
--- a/less/plugins/adapt-contrib-hotgraphic/hotgraphic.less
+++ b/less/plugins/adapt-contrib-hotgraphic/hotgraphic.less
@@ -1,4 +1,12 @@
 .hotgraphic {
+  &__pin.has-pin-image {
+    background-color: transparent;
+
+    .no-touch &:not(.is-disabled):not(.is-locked):hover {
+      background-color: transparent;
+    }
+  }
+
   &__pin:not(.has-pin-image) {
     background-color: @item-color;
     color: @item-color-inverted;


### PR DESCRIPTION
Fix #453 

### Fix
* Remove background color on Hot Graphic pins when using pin images

### Testing
See #453 