### PR TITLE
Update: Hotgraphic pin number inherits from the icon styles (fixes #282)

### DIFF
--- a/less/plugins/adapt-contrib-hotgraphic/hotgraphic.less
+++ b/less/plugins/adapt-contrib-hotgraphic/hotgraphic.less
@@ -27,9 +27,10 @@
   // Numbered pins
   // --------------------------------------------------
   &__pin-number {
-    height: @body-size;
-    width: @body-size;
-    line-height: @body-size;
+    height: @icon-size;
+    width: @icon-size;
+    font-size: @icon-size;
+    line-height: 1;
     text-align: center;
   }
 


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-hotgraphic/issues/282

### Subject of the enhancement
With the current implementation (PR [#281](https://github.com/adaptlearning/adapt-contrib-hotgraphic/pull/281)), the visited state pin displays larger than the unvisited number. The visited state inherits from `@icon-size` (`1.5rem`) whereas the number pin inherits from `@body-size` (`1rem`).

<img width="1491" alt="current_numbers" src="https://github.com/adaptlearning/adapt-contrib-hotgraphic/assets/7045330/a3b01529-b925-4a96-a6fd-f38734ad14b1">


In this PR, `.hotgraphic__pin-number` inherits the icon styles for consistent pin number and visited state. See screenshot below.

<img width="1499" alt="numbers_inherit_from_icon" src="https://github.com/adaptlearning/adapt-contrib-hotgraphic/assets/7045330/2321efeb-df6b-4db4-9e91-d0b4491c1f81">

### Testing PR
Set `_useNumberedPins: true` for Hotgraphic and select the pins. Set `"_isNarrativeOnMobile": false`, to review PR on mobile.

