### PR TITLE
Fix: Add 'page-view-ready' html class once page is ready

### DIFF
--- a/js/themeView.js
+++ b/js/themeView.js
@@ -6,8 +6,10 @@ export default class ThemeView extends Backbone.View {
 
   initialize() {
     this.setStyles();
+    this.resetPageViewReady();
 
     this.listenTo(Adapt, {
+      'pageView:ready': this.onPageViewReady,
       'device:changed': this.onDeviceResize,
       remove: this.remove
     });
@@ -15,6 +17,15 @@ export default class ThemeView extends Backbone.View {
 
   onDeviceResize() {
     this.setStyles();
+  }
+
+  onPageViewReady() {
+    // Add a class to <html> after all assets are loaded for a page.
+    $('html').addClass('page-view-ready');
+  }
+
+  resetPageViewReady() {
+    $('html').removeClass('page-view-ready');
   }
 
   remove() {


### PR DESCRIPTION
Fixes adaptlearning/adapt-contrib-core#423 

### Fix
* Adds the `page-view-ready` html class once the page is ready

### Testing
Add some CSS that animates an element once the page is ready and the loading screen has been removed.

You may want to enable device throttling or add a large image to the page to increase the loading time.

```
.page__title {
  transition: 0.5s all ease-in-out;
}

html.page-view-ready .page__title {
  color: fuchsia;
  transform: scale(1.05) rotate(-1deg) translate(1rem, -1rem);
}
```
The animation should not play until the loading screen has been removed.
