### PR TITLE
Fix: Add schema default values for background image styles (fixes #456)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -801,7 +801,7 @@
                     "_backgroundRepeat": {
                       "type": "string",
                       "required": false,
-                      "default": "",
+                      "default": "no-repeat",
                       "inputType": {"type":"Select", "options":["repeat","repeat-x","repeat-y","no-repeat"]},
                       "title": "Set if/how the background image repeats",
                       "help": "Repeat-x: The background image is repeated only horizontally. Repeat-y: The background image is repeated only vertically."
@@ -809,7 +809,7 @@
                     "_backgroundSize": {
                       "type": "string",
                       "required": false,
-                      "default": "",
+                      "default": "cover",
                       "inputType": {"type":"Select", "options":["auto","cover","contain","100% 100%"]},
                       "title": "Set the size of the background image",
                       "help": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container."
@@ -817,7 +817,7 @@
                     "_backgroundPosition": {
                       "type": "string",
                       "required": false,
-                      "default": "",
+                      "default": "center top",
                       "inputType": {"type":"Select", "options":["left top","left center","left bottom","center top","center center","center bottom","right top","right center","right bottom"]},
                       "title": "Set the position of the background image",
                       "help": "The first value is the horizontal position and the second value is the vertical."
@@ -945,7 +945,7 @@
                         "_backgroundRepeat": {
                           "type": "string",
                           "required": false,
-                          "default": "",
+                          "default": "no-repeat",
                           "inputType": {"type":"Select", "options":["repeat","repeat-x","repeat-y","no-repeat"]},
                           "title": "Set if/how the background image repeats",
                           "help": "Repeat-x: The background image is repeated only horizontally. Repeat-y: The background image is repeated only vertically."
@@ -953,7 +953,7 @@
                         "_backgroundSize": {
                           "type": "string",
                           "required": false,
-                          "default": "",
+                          "default": "cover",
                           "inputType": {"type":"Select", "options":["auto","cover","contain","100% 100%"]},
                           "title": "Set the size of the background image",
                           "help": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container."
@@ -961,7 +961,7 @@
                         "_backgroundPosition": {
                           "type": "string",
                           "required": false,
-                          "default": "",
+                          "default": "center top",
                           "inputType": {"type":"Select", "options":["left top","left center","left bottom","center top","center center","center bottom","right top","right center","right bottom"]},
                           "title": "Set the position of the background image",
                           "help": "The first value is the horizontal position and the second value is the vertical."
@@ -1098,7 +1098,7 @@
                     "_backgroundRepeat": {
                       "type": "string",
                       "required": false,
-                      "default": "",
+                      "default": "no-repeat",
                       "inputType": {"type":"Select", "options":["repeat","repeat-x","repeat-y","no-repeat"]},
                       "title": "Set if/how the background image repeats",
                       "help": "Repeat-x: The background image is repeated only horizontally. Repeat-y: The background image is repeated only vertically."
@@ -1106,7 +1106,7 @@
                     "_backgroundSize": {
                       "type": "string",
                       "required": false,
-                      "default": "",
+                      "default": "cover",
                       "inputType": {"type":"Select", "options":["auto","cover","contain","100% 100%"]},
                       "title": "Set the size of the background image",
                       "help": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container."
@@ -1114,7 +1114,7 @@
                     "_backgroundPosition": {
                       "type": "string",
                       "required": false,
-                      "default": "",
+                      "default": "center top",
                       "inputType": {"type":"Select", "options":["left top","left center","left bottom","center top","center center","center bottom","right top","right center","right bottom"]},
                       "title": "Set the position of the background image",
                       "help": "The first value is the horizontal position and the second value is the vertical."
@@ -1249,7 +1249,7 @@
                     "_backgroundRepeat": {
                       "type": "string",
                       "required": false,
-                      "default": "",
+                      "default": "no-repeat",
                       "inputType": {"type":"Select", "options":["repeat","repeat-x","repeat-y","no-repeat"]},
                       "title": "Set if/how the background image repeats",
                       "help": "Repeat-x: The background image is repeated only horizontally. Repeat-y: The background image is repeated only vertically."
@@ -1257,7 +1257,7 @@
                     "_backgroundSize": {
                       "type": "string",
                       "required": false,
-                      "default": "",
+                      "default": "cover",
                       "inputType": {"type":"Select", "options":["auto","cover","contain","100% 100%"]},
                       "title": "Set the size of the background image",
                       "help": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container."
@@ -1265,7 +1265,7 @@
                     "_backgroundPosition": {
                       "type": "string",
                       "required": false,
-                      "default": "",
+                      "default": "center top",
                       "inputType": {"type":"Select", "options":["left top","left center","left bottom","center top","center center","center bottom","right top","right center","right bottom"]},
                       "title": "Set the position of the background image",
                       "help": "The first value is the horizontal position and the second value is the vertical."

--- a/schema/article.schema.json
+++ b/schema/article.schema.json
@@ -117,7 +117,6 @@
                   "description": "Repeat-x: The background image is repeated only horizontally. Repeat-y: The background image is repeated only vertically",
                   "default": "no-repeat",
                   "enum": [
-                    "",
                     "repeat",
                     "repeat-x",
                     "repeat-y",
@@ -131,7 +130,6 @@
                   "description": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container",
                   "default": "cover",
                   "enum": [
-                    "",
                     "auto",
                     "cover",
                     "contain",
@@ -145,7 +143,6 @@
                   "description": "The first value is the horizontal position and the second value is the vertical",
                   "default": "center top",
                   "enum": [
-                    "",
                     "left top",
                     "left center",
                     "left bottom",

--- a/schema/article.schema.json
+++ b/schema/article.schema.json
@@ -115,7 +115,7 @@
                   "type": "string",
                   "title": "Repeat",
                   "description": "Repeat-x: The background image is repeated only horizontally. Repeat-y: The background image is repeated only vertically",
-                  "default": "",
+                  "default": "no-repeat",
                   "enum": [
                     "",
                     "repeat",
@@ -129,7 +129,7 @@
                   "type": "string",
                   "title": "Size",
                   "description": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container",
-                  "default": "",
+                  "default": "cover",
                   "enum": [
                     "",
                     "auto",
@@ -143,7 +143,7 @@
                   "type": "string",
                   "title": "Position",
                   "description": "The first value is the horizontal position and the second value is the vertical",
-                  "default": "",
+                  "default": "center top",
                   "enum": [
                     "",
                     "left top",

--- a/schema/block.schema.json
+++ b/schema/block.schema.json
@@ -117,7 +117,6 @@
                   "description": "Repeat-x: The background image is repeated only horizontally. Repeat-y: The background image is repeated only vertically",
                   "default": "no-repeat",
                   "enum": [
-                    "",
                     "repeat",
                     "repeat-x",
                     "repeat-y",
@@ -131,7 +130,6 @@
                   "description": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container",
                   "default": "cover",
                   "enum": [
-                    "",
                     "auto",
                     "cover",
                     "contain",
@@ -145,7 +143,6 @@
                   "description": "The first value is the horizontal position and the second value is the vertical",
                   "default": "center top",
                   "enum": [
-                    "",
                     "left top",
                     "left center",
                     "left bottom",

--- a/schema/block.schema.json
+++ b/schema/block.schema.json
@@ -115,7 +115,7 @@
                   "type": "string",
                   "title": "Repeat",
                   "description": "Repeat-x: The background image is repeated only horizontally. Repeat-y: The background image is repeated only vertically",
-                  "default": "",
+                  "default": "no-repeat",
                   "enum": [
                     "",
                     "repeat",
@@ -129,7 +129,7 @@
                   "type": "string",
                   "title": "Size",
                   "description": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container",
-                  "default": "",
+                  "default": "cover",
                   "enum": [
                     "",
                     "auto",
@@ -143,7 +143,7 @@
                   "type": "string",
                   "title": "Position",
                   "description": "The first value is the horizontal position and the second value is the vertical",
-                  "default": "",
+                  "default": "center top",
                   "enum": [
                     "",
                     "left top",

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -69,7 +69,7 @@
                   "type": "string",
                   "title": "Repeat",
                   "description": "Repeat-x: The background image is repeated only horizontally. Repeat-y: The background image is repeated only vertically",
-                  "default": "",
+                  "default": "no-repeat",
                   "enum": [
                     "",
                     "repeat",
@@ -83,7 +83,7 @@
                   "type": "string",
                   "title": "Size",
                   "description": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container",
-                  "default": "",
+                  "default": "cover",
                   "enum": [
                     "",
                     "auto",
@@ -97,7 +97,7 @@
                   "type": "string",
                   "title": "Position",
                   "description": "The first value is the horizontal position and the second value is the vertical",
-                  "default": "",
+                  "default": "center top",
                   "enum": [
                     "",
                     "left top",
@@ -252,7 +252,7 @@
                       "type": "string",
                       "title": "Repeat",
                       "description": "Repeat-x: The background image is repeated only horizontally. Repeat-y: The background image is repeated only vertically",
-                      "default": "",
+                      "default": "no-repeat",
                       "enum": [
                         "",
                         "repeat",
@@ -266,7 +266,7 @@
                       "type": "string",
                       "title": "Size",
                       "description": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container",
-                      "default": "",
+                      "default": "cover",
                       "enum": [
                         "",
                         "auto",
@@ -280,7 +280,7 @@
                       "type": "string",
                       "title": "Position",
                       "description": "The first value is the horizontal position and the second value is the vertical",
-                      "default": "",
+                      "default": "center top",
                       "enum": [
                         "",
                         "left top",

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -254,7 +254,6 @@
                       "description": "Repeat-x: The background image is repeated only horizontally. Repeat-y: The background image is repeated only vertically",
                       "default": "no-repeat",
                       "enum": [
-                        "",
                         "repeat",
                         "repeat-x",
                         "repeat-y",
@@ -268,7 +267,6 @@
                       "description": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container",
                       "default": "cover",
                       "enum": [
-                        "",
                         "auto",
                         "cover",
                         "contain",
@@ -282,7 +280,6 @@
                       "description": "The first value is the horizontal position and the second value is the vertical",
                       "default": "center top",
                       "enum": [
-                        "",
                         "left top",
                         "left center",
                         "left bottom",

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -71,7 +71,6 @@
                   "description": "Repeat-x: The background image is repeated only horizontally. Repeat-y: The background image is repeated only vertically",
                   "default": "no-repeat",
                   "enum": [
-                    "",
                     "repeat",
                     "repeat-x",
                     "repeat-y",
@@ -85,7 +84,6 @@
                   "description": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container",
                   "default": "cover",
                   "enum": [
-                    "",
                     "auto",
                     "cover",
                     "contain",
@@ -99,7 +97,6 @@
                   "description": "The first value is the horizontal position and the second value is the vertical",
                   "default": "center top",
                   "enum": [
-                    "",
                     "left top",
                     "left center",
                     "left bottom",


### PR DESCRIPTION
Fix #456 

### Fix
* Adds schema default values for Background image styles

### Testing
1. Upload plugin to an AAT instance
2. Verify that there are default values for Repeat, Size and Position under Background image styles