### PR TITLE
Fix: Add 'bg-color white' mixin (fixes #460)

### DIFF
--- a/less/project/theme-common.less
+++ b/less/project/theme-common.less
@@ -8,6 +8,7 @@
 // Note: both arguments must be predefined variables
 // --------------------------------------------------
 .bg-color-mixin(black, white);
+.bg-color-mixin(white, black);
 .bg-color-mixin(background, background-inverted);
 .bg-color-mixin(transparent-light, black);
 .bg-color-mixin(transparent-dark, white);


### PR DESCRIPTION
Fix #460 

### Fix
* Adds a white bg-color-mixin() to the out-of-the-box background color mixins

### Testing
1. Add `bg-color white` to a block, component, etc.
