### PR TITLE
Fix: background and headerBackground undefined variable errors (fixes #462)

### DIFF
--- a/js/themePageView.js
+++ b/js/themePageView.js
@@ -37,7 +37,8 @@ export default class ThemePageView extends ThemeView {
 
   setHeaderBackgroundImage(config, $header) {
     const backgroundImages = config._backgroundImage;
-    if (!backgroundImages) return;
+    if (!backgroundImages || this.$headerBackground) return;
+
     const backgroundImage = backgroundImages[`_${Adapt.device.screenSize}`] ?? backgroundImages._small;
     $header.toggleClass('has-bg-image', Boolean(backgroundImage));
     this.$headerBackground.css('background-image', backgroundImage ? 'url(' + backgroundImage + ')' : '');
@@ -45,7 +46,8 @@ export default class ThemePageView extends ThemeView {
 
   setHeaderBackgroundStyles(config, $header) {
     const styles = config._backgroundStyles;
-    if (!styles) return;
+    if (!styles || this.$headerBackground) return;
+
     this.$headerBackground.css({
       'background-repeat': styles._backgroundRepeat,
       'background-size': styles._backgroundSize,

--- a/js/themePageView.js
+++ b/js/themePageView.js
@@ -37,7 +37,7 @@ export default class ThemePageView extends ThemeView {
 
   setHeaderBackgroundImage(config, $header) {
     const backgroundImages = config._backgroundImage;
-    if (!backgroundImages || this.$headerBackground) return;
+    if (!backgroundImages || !this.$headerBackground) return;
 
     const backgroundImage = backgroundImages[`_${device.screenSize}`] ?? backgroundImages._small;
     $header.toggleClass('has-bg-image', Boolean(backgroundImage));
@@ -46,7 +46,7 @@ export default class ThemePageView extends ThemeView {
 
   setHeaderBackgroundStyles(config, $header) {
     const styles = config._backgroundStyles;
-    if (!styles || this.$headerBackground) return;
+    if (!styles || !this.$headerBackground) return;
 
     this.$headerBackground.css({
       'background-repeat': styles._backgroundRepeat,

--- a/js/themePageView.js
+++ b/js/themePageView.js
@@ -1,5 +1,5 @@
 import ThemeView from './themeView';
-import Adapt from 'core/js/adapt';
+import device from 'core/js/device';
 
 export default class ThemePageView extends ThemeView {
 
@@ -39,7 +39,7 @@ export default class ThemePageView extends ThemeView {
     const backgroundImages = config._backgroundImage;
     if (!backgroundImages || this.$headerBackground) return;
 
-    const backgroundImage = backgroundImages[`_${Adapt.device.screenSize}`] ?? backgroundImages._small;
+    const backgroundImage = backgroundImages[`_${device.screenSize}`] ?? backgroundImages._small;
     $header.toggleClass('has-bg-image', Boolean(backgroundImage));
     this.$headerBackground.css('background-image', backgroundImage ? 'url(' + backgroundImage + ')' : '');
   }
@@ -58,7 +58,7 @@ export default class ThemePageView extends ThemeView {
   setHeaderMinimumHeight(config, $header) {
     const minimumHeights = config._minimumHeights;
     if (!minimumHeights) return;
-    const minimumHeight = minimumHeights[`_${Adapt.device.screenSize}`] ?? minimumHeights._small;
+    const minimumHeight = minimumHeights[`_${device.screenSize}`] ?? minimumHeights._small;
     $header
       .toggleClass('has-min-height', Boolean(minimumHeight))
       .css('min-height', minimumHeight ? minimumHeight + 'px' : '');

--- a/js/themeView.js
+++ b/js/themeView.js
@@ -55,6 +55,7 @@ export default class ThemeView extends Backbone.View {
   setBackgroundImage() {
     const backgroundImages = this.model.get('_backgroundImage');
     if (!backgroundImages || !this.$background) return;
+
     const backgroundImage = backgroundImages[`_${Adapt.device.screenSize}`] ?? backgroundImages._small;
     this.$el.toggleClass('has-bg-image', Boolean(backgroundImage));
     this.$background
@@ -64,6 +65,7 @@ export default class ThemeView extends Backbone.View {
   setBackgroundStyles() {
     const styles = this.model.get('_backgroundStyles');
     if (!styles || !this.$background) return;
+
     this.$background.css({
       'background-repeat': styles._backgroundRepeat,
       'background-size': styles._backgroundSize,

--- a/js/themeView.js
+++ b/js/themeView.js
@@ -1,4 +1,5 @@
 import Adapt from 'core/js/adapt';
+import device from 'core/js/device';
 
 export default class ThemeView extends Backbone.View {
 
@@ -56,7 +57,7 @@ export default class ThemeView extends Backbone.View {
     const backgroundImages = this.model.get('_backgroundImage');
     if (!backgroundImages || !this.$background) return;
 
-    const backgroundImage = backgroundImages[`_${Adapt.device.screenSize}`] ?? backgroundImages._small;
+    const backgroundImage = backgroundImages[`_${device.screenSize}`] ?? backgroundImages._small;
     this.$el.toggleClass('has-bg-image', Boolean(backgroundImage));
     this.$background
       .css('background-image', backgroundImage ? 'url(' + backgroundImage + ')' : '');
@@ -77,7 +78,7 @@ export default class ThemeView extends Backbone.View {
     const minimumHeights = this.model.get('_minimumHeights');
     if (!minimumHeights) return;
 
-    const minimumHeight = minimumHeights[`_${Adapt.device.screenSize}`] ?? minimumHeights._small;
+    const minimumHeight = minimumHeights[`_${device.screenSize}`] ?? minimumHeights._small;
     this.$el
       .toggleClass('has-min-height', Boolean(minimumHeight))
       .css('min-height', minimumHeight ? minimumHeight + 'px' : '');
@@ -89,7 +90,7 @@ export default class ThemeView extends Backbone.View {
 
     this.$el
       .removeClass(Object.values(responsiveClasses))
-      .addClass(responsiveClasses[`_${Adapt.device.screenSize}`]);
+      .addClass(responsiveClasses[`_${device.screenSize}`]);
   }
 
   setCustomStyles() {}

--- a/js/themeView.js
+++ b/js/themeView.js
@@ -54,7 +54,7 @@ export default class ThemeView extends Backbone.View {
 
   setBackgroundImage() {
     const backgroundImages = this.model.get('_backgroundImage');
-    if (!backgroundImages) return;
+    if (!backgroundImages || !this.$background) return;
     const backgroundImage = backgroundImages[`_${Adapt.device.screenSize}`] ?? backgroundImages._small;
     this.$el.toggleClass('has-bg-image', Boolean(backgroundImage));
     this.$background
@@ -63,7 +63,7 @@ export default class ThemeView extends Backbone.View {
 
   setBackgroundStyles() {
     const styles = this.model.get('_backgroundStyles');
-    if (!styles) return;
+    if (!styles || !this.$background) return;
     this.$background.css({
       'background-repeat': styles._backgroundRepeat,
       'background-size': styles._backgroundSize,


### PR DESCRIPTION
Fixes #462

### Fix
* Exit early from `setHeaderBackgroundImage()` and `setHeaderBackgroundStyles()` if `this.$headerBackground` has not been set
* Exit early from `setBackgroundImage()` and `setBackgroundStyles()` if `this.$background` has not been set
* Fix deprecated `Adapt.device` references