### PR TITLE
Update: use display flex to set equal menu item heights (fixes #466)

### DIFF
--- a/less/plugins/adapt-contrib-boxmenu/boxMenuItem.less
+++ b/less/plugins/adapt-contrib-boxmenu/boxMenuItem.less
@@ -1,5 +1,8 @@
 .boxmenu-item {
+  display: flex;
+  
   &__inner {
+    width: 100%;
     margin: 0 @menu-item-padding-hoz @menu-item-padding-ver;
     padding: 1rem;
     background-color: @menu-item;

--- a/less/plugins/adapt-contrib-boxmenu/boxMenuItem.less
+++ b/less/plugins/adapt-contrib-boxmenu/boxMenuItem.less
@@ -41,7 +41,6 @@
   &__button-container {
     display: flex;
     align-items: center;
-    margin-bottom: @menu-item-progress-margin;
   }
 
   &__button {


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-vanilla/issues/466 and https://github.com/adaptlearning/adapt-contrib-vanilla/issues/465

## Set equal menu item heights
Currently, the height of menu items is based on the amount of text content which leads to inconsistent item heights.

This PR uses `display: flex` to display all items at equal height with no constraints on the content. Please see below for screenshots of how this looks in different use cases.

 **Standard display:**
<img width="508" alt="standard_display" src="https://github.com/adaptlearning/adapt-contrib-vanilla/assets/7045330/f6992fbb-237c-430f-8377-54641bb59109">


**Items using [column layout](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/master/less/project/columns.less):**
<img width="508" alt="column_layout" src="https://github.com/adaptlearning/adapt-contrib-vanilla/assets/7045330/7f13a578-d9ca-4038-84f8-ca5d1eb9b65c">


**Items without image:**
<img width="504" alt="no_image" src="https://github.com/adaptlearning/adapt-contrib-vanilla/assets/7045330/c380ea6f-d45f-41f5-bb11-12b0a3aa556a">

## Remove button container margin

I've also included #465 in this PR. The `margin-bottom` attached to the `.boxmenu-item__button-container` creates inconsistent spacing around the item (1rem top/left/right and 2rem bottom). As the `.boxmenu-item__button-container` is the last item in the menu item, and there is already padding applied to the `.boxmenu-item__inner`, the margin here isn't needed.