### PR TITLE
Update: Update visited color variables (fixes #470)

### DIFF
--- a/less/_defaults/_colors.less
+++ b/less/_defaults/_colors.less
@@ -47,8 +47,8 @@
 
 // Visited - presentation components
 // --------------------------------------------------
-@visited: #727272;
-@visited-inverted: @white;
+@visited: darken(@item-color, 15%);
+@visited-inverted: @item-color-inverted;
 
 // Buttons
 // --------------------------------------------------


### PR DESCRIPTION
Grey is widely recognised, and used in Adapt for disabled states so changing the visited colours to differentiate between the two. Variables replaced with a percentage of `@item-color` for consistency with other component states.

Fixes https://github.com/adaptlearning/adapt-contrib-vanilla/issues/470