### PR TITLE
Fix: Neutralised `nav-btn-*` variables (fixes #476)

### DIFF
--- a/less/_defaults/_spacing-config.less
+++ b/less/_defaults/_spacing-config.less
@@ -18,9 +18,9 @@
 
 // Navigation
 // --------------------------------------------------
-@nav-btn-margin: .5rem;
+@nav-btn-margin: 0;
 
-@nav-btn-border-radius: @btn-border-radius;
+@nav-btn-border-radius: 0;
 
 // Menu header text margin
 // --------------------------------------------------


### PR DESCRIPTION
Fixes: #476 

### Fix
* Sets the `@nav-btn-*` variables to 0 so they have no visual impact on the builds but are there to be used if required
