### PR TITLE
Fix: prevent notify btn hover style override (fixes #482)

### DIFF
--- a/less/core/notify.less
+++ b/less/core/notify.less
@@ -55,7 +55,7 @@
     background-color: @notify-btn;
     color: @notify-btn-inverted;
 
-    .no-touch &:not(.is-disabled):hover {
+    .no-touch &:not(.is-disabled):not(.is-locked):hover {
       background-color: @notify-btn-hover;
       color: @notify-btn-inverted-hover;
       .transition(background-color @duration ease-in, color @duration ease-in;);


### PR DESCRIPTION
Prevent generic `.btn-text `style overriding `.notify__btn` hover state by applying the same `:not` logic used in [less/core/buttons.less](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/cb5fc98607b042487566bab99daf4c784f5f2afd/less/core/button.less#L26). Hover states should exclude locked and disabled states anyway.

Fixes https://github.com/adaptlearning/adapt-contrib-vanilla/issues/482