### PR TITLE
Only set .drawer__item-title margin if followed by .drawer__item-body

### DIFF
--- a/less/core/drawerItem.less
+++ b/less/core/drawerItem.less
@@ -24,11 +24,14 @@
   }
 
   &__item-title {
-    margin-bottom: @drawer-title-margin;
     .drawer-item-title;
     text-align: start;
   }
-
+  
+  &__item-title + &__item-body {
+    margin-top: @drawer-title-margin;
+  }
+  
   &__item-body {
     margin-bottom: @drawer-body-margin;
     .drawer-item-body;


### PR DESCRIPTION
Instead of applying `margin-bottom` to `.drawer__item-title` directly, apply `margin-top` to `.drawer__item-body` when needed.

Most Drawer plugin items only include a title. It's a minor issue but the addition of margin makes the title display off-center vertically.

Fixes https://github.com/adaptlearning/adapt-contrib-vanilla/issues/486

**Test PR**
In your course, go to PageLevelProgress and inspect `.drawer__item-title`. No margin should be applied. Same goes for Glossary or LanguagePicker.

Go to Drawer Resources and inspect `.drawer__item-title`. Margin should be applied to the top of `.drawer__item-body`, creating space between title and body.