### PR TITLE
New: Add drawer item locked state 

### DIFF
--- a/less/core/drawerItem.less
+++ b/less/core/drawerItem.less
@@ -13,6 +13,7 @@
     }
   }
 
+  &__item-btn.is-locked,
   &__item-btn.is-disabled {
     background-color: @disabled;
     color: @disabled-inverted;

--- a/less/plugins/adapt-contrib-pageLevelProgress/pageLevelProgressIndicator.less
+++ b/less/plugins/adapt-contrib-pageLevelProgress/pageLevelProgressIndicator.less
@@ -73,7 +73,7 @@
 
 // Drawer overrides
 // --------------------------------------------------
-.pagelevelprogress__item-btn:not(.is-locked):not(.is-disabled) {
+.pagelevelprogress__item-btn:not(.is-disabled) {
   .pagelevelprogress__indicator {
     border-color: @drawer-progress-border;
   }
@@ -104,7 +104,6 @@
   }
 }
 
-.pagelevelprogress__item-btn.is-locked,
 .pagelevelprogress__item-btn.is-disabled {
   .pagelevelprogress__indicator {
     border-color: @disabled-inverted;

--- a/less/plugins/adapt-contrib-pageLevelProgress/pageLevelProgressIndicator.less
+++ b/less/plugins/adapt-contrib-pageLevelProgress/pageLevelProgressIndicator.less
@@ -73,7 +73,7 @@
 
 // Drawer overrides
 // --------------------------------------------------
-.pagelevelprogress__item-btn:not(.is-disabled) {
+.pagelevelprogress__item-btn:not(.is-locked):not(.is-disabled) {
   .pagelevelprogress__indicator {
     border-color: @drawer-progress-border;
   }
@@ -104,6 +104,7 @@
   }
 }
 
+.pagelevelprogress__item-btn.is-locked,
 .pagelevelprogress__item-btn.is-disabled {
   .pagelevelprogress__indicator {
     border-color: @disabled-inverted;


### PR DESCRIPTION
Relates to Core issue to [allow for locked and inactive disabled buttons to be visually different](https://github.com/adaptlearning/adapt-contrib-core/issues/485).

`.is-locked` - applies to buttons that are temporarily disabled due to step locked content.

`.is-disabled` - applies to buttons with functionality not available.

Drawer item locked state inherits from disabled state by default so there will be no visual changes. By introducing `.is-locked` class, this gives the flexibility of setting locked styling that can differ from the standard disabled styling.

