### PR TITLE
Fix: remove legacy z-index from slider number selection / model answer (fixes #484)

### DIFF
--- a/less/plugins/adapt-contrib-slider/slider.less
+++ b/less/plugins/adapt-contrib-slider/slider.less
@@ -26,13 +26,11 @@
   &__number-selection {
     background-color: @item-color;
     color: @item-color-inverted;
-    z-index: 5;
   }
 
   &__number-model-answer {
     background-color: @item-color;
     color: @item-color-inverted;
-    z-index: 10;
   }
 
   // Scale


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-vanilla/issues/484

### Fix
* Remove legacy `z-index` properties from `.slider__number-selection` and `.slider__number-model-answer`.

[//]: # (List appropriate steps for testing if needed)
### Testing

1. Enable Tutor `"_type": "overlay"` in a course, as per [example.json](https://github.com/adaptlearning/adapt-contrib-tutor/blob/ae525c06dfb0ca97e4a7bf96fb9a42ace93db3b0/example.json#L3).
2. Navigate to a Slider within your course and submit. 
3. Toggle _"Show correct answer"_ / _"show your answer"_ buttons to see both instances when feedback is displayed.

Tested on Mac Safari, Chrome, FF, iPhone and Chrome on Android. Please test on Windows.




