### PR TITLE
Fix: Change @max-width to 100%, remove max-width: inherit from .page (fixes #493)

### DIFF
--- a/less/_defaults/_spacing-containers.less
+++ b/less/_defaults/_spacing-containers.less
@@ -5,8 +5,7 @@
 @device-width-large: unit(@adapt-device-large, rem);
 @device-width-xlarge: unit(@adapt-device-xlarge, rem);
 
-@max-width: 90rem;
-
+@max-width: 100%;
 @max-content-width: @device-width-large;
 @max-page-width: @max-width;
 

--- a/less/core/page.less
+++ b/less/core/page.less
@@ -1,6 +1,5 @@
 .page {
   position: relative;
-  max-width: inherit;
   .l-container-padding(@page-padding-ver, @page-padding-hoz);
 
   &.has-bg-image > .background {


### PR DESCRIPTION
Fixes #493 

### Fix
* Changes `@max-width` to 100%
* Removes `max-width: inherit` from the `.page` element

### Testing
1. In your theme's CSS:
```
@body-background-color: #96D5E4;

.page {
  background-color: @white;
}
```
2. Change `@max-width` variable to 90rem

### Expected results
Blue body background color is visible on the sides.

<img src="https://github.com/adaptlearning/adapt-contrib-vanilla/assets/898168/4310c07e-d5fd-48f9-8a51-c60a4ae71948" width="500">