### PR TITLE
Fix: Utilize .size-small class for .hide-on-mobile class (fixes #492)

### DIFF
--- a/less/project/theme-common.less
+++ b/less/project/theme-common.less
@@ -92,8 +92,6 @@
   }
 }
 
-.hide-on-mobile {
-  @media (max-width: @device-width-medium) {
-    display: none;
-  }
+.size-small .hide-on-mobile {
+  display: none;
 }


### PR DESCRIPTION
Fix #492 

### Fix
* Utilize the `.size-small` html class to determine when `.hide-on-mobile` applies

### Testing
See #492 

