### PR TITLE
Update: Replace PLP hard coded border-radius with variable (fixes #498)

### DIFF
--- a/less/_defaults/_spacing-config.less
+++ b/less/_defaults/_spacing-config.less
@@ -25,7 +25,6 @@
 
 // Progress
 // --------------------------------------------------
-@progress-border-width: 0.0625rem;
 @progress-border-radius: 50px;
 
 // Menu header text margin

--- a/less/_defaults/_spacing-config.less
+++ b/less/_defaults/_spacing-config.less
@@ -22,6 +22,12 @@
 
 @nav-btn-border-radius: 0;
 
+
+// Progress
+// --------------------------------------------------
+@progress-border-width: 0.0625rem;
+@progress-border-radius: 50px;
+
 // Menu header text margin
 // --------------------------------------------------
 @menu-title-margin: 1rem;

--- a/less/plugins/adapt-contrib-pageLevelProgress/pageLevelProgressIndicator.less
+++ b/less/plugins/adapt-contrib-pageLevelProgress/pageLevelProgressIndicator.less
@@ -9,6 +9,8 @@
 // --------------------------------------------------
 .pagelevelprogress {
   &__indicator {
+    border-width: @progress-border-width;
+    border-radius: @progress-border-radius;
     border-color: @progress-border;
   }
 

--- a/less/plugins/adapt-contrib-pageLevelProgress/pageLevelProgressIndicator.less
+++ b/less/plugins/adapt-contrib-pageLevelProgress/pageLevelProgressIndicator.less
@@ -9,7 +9,6 @@
 // --------------------------------------------------
 .pagelevelprogress {
   &__indicator {
-    border-width: @progress-border-width;
     border-radius: @progress-border-radius;
     border-color: @progress-border;
   }


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-vanilla/issues/498

### Update
`@progress-border-radius` variable added for ease of amending the look of the indicator. The default value has been set to 50px for consistency with the plugin value and prevent any visual change in existing courses.

PLP indicator as default, `@progress-border-radius: 50px`:
<img width="117" alt="standard" src="https://github.com/adaptlearning/adapt-contrib-vanilla/assets/7045330/7d9cadb1-8d76-40dc-9267-f175658270c2">

Remove rounded corners setting `@progress-border-radius: 0`:
<img width="138" alt="remove_border_radius" src="https://github.com/adaptlearning/adapt-contrib-vanilla/assets/7045330/35af20ea-7572-45bb-975e-0ed7e6e08893">




