### PR TITLE
New: Add margin start and margin end column classes (fixes #504)

### DIFF
--- a/less/project/columns.less
+++ b/less/project/columns.less
@@ -1,3 +1,8 @@
+// Custom classes
+// e.g. 'col-sm-8 col-md-10'
+// min small viewport takes up 8 out of 12 columns
+// min medium viewport takes up 10 columns
+// if undefined element defaults to 100% width
 .make-columns(@size, @media-query, @count, @iteration: 1) when (@count >= @iteration) {
   @media (min-width: @media-query) {
     .boxmenu-item.col-@{size}-@{iteration} {
@@ -11,13 +16,56 @@
   .make-columns(@size, @media-query, @count, (@iteration + 1));
 }
 
-// Custom classes
-// e.g. 'col-sm-8 col-md-10'
-// min small viewport takes up 8 out of 12 columns
-// min medium viewport takes up 10 columns
-// if undefined element defaults to 100% width
 .make-columns(xs, 0, 12); // deprecated: backward compatibility only
 .make-columns(sm, @device-width-small, 12);
 .make-columns(md, @device-width-medium, 12);
 .make-columns(lg, @device-width-large, 12);
 .make-columns(xl, @device-width-xlarge, 12);
+
+// Custom push classes
+// e.g. 'col-push-sm-2 col-push-md-1'
+// min small viewport indents 2 columns from the left (or right for RTL)
+// min medium viewport indents 1 column from the left (or right for RTL)
+// if undefined element defaults to 100% width
+.make-columns-push(@size, @media-query, @count, @iteration: 1) when (@count >= @iteration) {
+  @media (min-width: @media-query) {
+    .boxmenu-item.col-push-@{size}-@{iteration} {
+      margin-inline-start: (@iteration * 100% / @count);
+    }
+    .component.col-push-@{size}-@{iteration} {
+      margin-inline-start: (@iteration * 100% / @count);
+    }
+  }
+
+  .make-columns-push(@size, @media-query, @count, (@iteration + 1));
+}
+
+.make-columns-push(xs, 0, 12); // deprecated: backward compatibility only
+.make-columns-push(sm, @device-width-small, 12);
+.make-columns-push(md, @device-width-medium, 12);
+.make-columns-push(lg, @device-width-large, 12);
+.make-columns-push(xl, @device-width-xlarge, 12);
+
+// Custom pull classes
+// e.g. 'col-pull-sm-2 col-pull-md-1'
+// min small viewport indents 2 columns from the right (or left for RTL)
+// min medium viewport indents 1 column from the right (or left for RTL)
+// if undefined element defaults to 100% width
+.make-columns-pull(@size, @media-query, @count, @iteration: 1) when (@count >= @iteration) {
+  @media (min-width: @media-query) {
+    .boxmenu-item.col-pull-@{size}-@{iteration} {
+      margin-inline-end: (@iteration * 100% / @count);
+    }
+    .component.col-pull-@{size}-@{iteration} {
+      margin-inline-end: (@iteration * 100% / @count);
+    }
+  }
+
+  .make-columns-pull(@size, @media-query, @count, (@iteration + 1));
+}
+
+.make-columns-pull(xs, 0, 12); // deprecated: backward compatibility only
+.make-columns-pull(sm, @device-width-small, 12);
+.make-columns-pull(md, @device-width-medium, 12);
+.make-columns-pull(lg, @device-width-large, 12);
+.make-columns-pull(xl, @device-width-xlarge, 12);

--- a/less/project/columns.less
+++ b/less/project/columns.less
@@ -1,8 +1,8 @@
-// Custom classes
+// Custom column classes
 // e.g. 'col-sm-8 col-md-10'
 // min small viewport takes up 8 out of 12 columns
 // min medium viewport takes up 10 columns
-// if undefined element defaults to 100% width
+// if undefined, element defaults to 100% width
 .make-columns(@size, @media-query, @count, @iteration: 1) when (@count >= @iteration) {
   @media (min-width: @media-query) {
     .boxmenu-item.col-@{size}-@{iteration} {
@@ -22,11 +22,11 @@
 .make-columns(lg, @device-width-large, 12);
 .make-columns(xl, @device-width-xlarge, 12);
 
-// Custom push classes
+// Custom column push classes
 // e.g. 'col-push-sm-2 col-push-md-1'
 // min small viewport indents 2 columns from the left (or right for RTL)
 // min medium viewport indents 1 column from the left (or right for RTL)
-// if undefined element defaults to 100% width
+// if undefined, element defaults to 100% width
 .make-columns-push(@size, @media-query, @count, @iteration: 1) when (@count >= @iteration) {
   @media (min-width: @media-query) {
     .boxmenu-item.col-push-@{size}-@{iteration} {
@@ -40,17 +40,16 @@
   .make-columns-push(@size, @media-query, @count, (@iteration + 1));
 }
 
-.make-columns-push(xs, 0, 12); // deprecated: backward compatibility only
 .make-columns-push(sm, @device-width-small, 12);
 .make-columns-push(md, @device-width-medium, 12);
 .make-columns-push(lg, @device-width-large, 12);
 .make-columns-push(xl, @device-width-xlarge, 12);
 
-// Custom pull classes
+// Custom column pull classes
 // e.g. 'col-pull-sm-2 col-pull-md-1'
 // min small viewport indents 2 columns from the right (or left for RTL)
 // min medium viewport indents 1 column from the right (or left for RTL)
-// if undefined element defaults to 100% width
+// if undefined, element defaults to 100% width
 .make-columns-pull(@size, @media-query, @count, @iteration: 1) when (@count >= @iteration) {
   @media (min-width: @media-query) {
     .boxmenu-item.col-pull-@{size}-@{iteration} {
@@ -64,7 +63,6 @@
   .make-columns-pull(@size, @media-query, @count, (@iteration + 1));
 }
 
-.make-columns-pull(xs, 0, 12); // deprecated: backward compatibility only
 .make-columns-pull(sm, @device-width-small, 12);
 .make-columns-pull(md, @device-width-medium, 12);
 .make-columns-pull(lg, @device-width-large, 12);

--- a/less/project/columns.less
+++ b/less/project/columns.less
@@ -22,48 +22,46 @@
 .make-columns(lg, @device-width-large, 12);
 .make-columns(xl, @device-width-xlarge, 12);
 
-// Custom column push classes
-// e.g. 'col-push-sm-2 col-push-md-1'
+// Custom column starting margin classes
+// e.g. 'margin-start-sm-2 margin-start-md-1'
 // min small viewport indents 2 columns from the left (or right for RTL)
 // min medium viewport indents 1 column from the left (or right for RTL)
-// if undefined, element defaults to 100% width
-.make-columns-push(@size, @media-query, @count, @iteration: 1) when (@count >= @iteration) {
+.make-margin-start(@size, @media-query, @count, @iteration: 1) when (@count >= @iteration) {
   @media (min-width: @media-query) {
-    .boxmenu-item.col-push-@{size}-@{iteration} {
+    .boxmenu-item.margin-start-@{size}-@{iteration} {
       margin-inline-start: (@iteration * 100% / @count);
     }
-    .component.col-push-@{size}-@{iteration} {
+    .component.margin-start-@{size}-@{iteration} {
       margin-inline-start: (@iteration * 100% / @count);
     }
   }
 
-  .make-columns-push(@size, @media-query, @count, (@iteration + 1));
+  .make-margin-start(@size, @media-query, @count, (@iteration + 1));
 }
 
-.make-columns-push(sm, @device-width-small, 12);
-.make-columns-push(md, @device-width-medium, 12);
-.make-columns-push(lg, @device-width-large, 12);
-.make-columns-push(xl, @device-width-xlarge, 12);
+.make-margin-start(sm, @device-width-small, 12);
+.make-margin-start(md, @device-width-medium, 12);
+.make-margin-start(lg, @device-width-large, 12);
+.make-margin-start(xl, @device-width-xlarge, 12);
 
-// Custom column pull classes
-// e.g. 'col-pull-sm-2 col-pull-md-1'
+// Custom column ending margin classes
+// e.g. 'margin-end-sm-2 margin-end-md-1'
 // min small viewport indents 2 columns from the right (or left for RTL)
 // min medium viewport indents 1 column from the right (or left for RTL)
-// if undefined, element defaults to 100% width
-.make-columns-pull(@size, @media-query, @count, @iteration: 1) when (@count >= @iteration) {
+.make-margin-end(@size, @media-query, @count, @iteration: 1) when (@count >= @iteration) {
   @media (min-width: @media-query) {
-    .boxmenu-item.col-pull-@{size}-@{iteration} {
+    .boxmenu-item.margin-end-@{size}-@{iteration} {
       margin-inline-end: (@iteration * 100% / @count);
     }
-    .component.col-pull-@{size}-@{iteration} {
+    .component.margin-end-@{size}-@{iteration} {
       margin-inline-end: (@iteration * 100% / @count);
     }
   }
 
-  .make-columns-pull(@size, @media-query, @count, (@iteration + 1));
+  .make-margin-end(@size, @media-query, @count, (@iteration + 1));
 }
 
-.make-columns-pull(sm, @device-width-small, 12);
-.make-columns-pull(md, @device-width-medium, 12);
-.make-columns-pull(lg, @device-width-large, 12);
-.make-columns-pull(xl, @device-width-xlarge, 12);
+.make-margin-end(sm, @device-width-small, 12);
+.make-margin-end(md, @device-width-medium, 12);
+.make-margin-end(lg, @device-width-large, 12);
+.make-margin-end(xl, @device-width-xlarge, 12);


### PR DESCRIPTION
Fixes #504 

### New
* Adds new margin start and margin end column classes (e.g. `margin-start-sm-2` and `margin-end-md-1`) for indenting components from the left or right.

### Testing
Configure two single width components using the existing [column](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/Custom-Classes#columns) classes and the new margin classes. For example, in the same block:

**Single width Text component**
Add classes `col-md-5 margin-start-md-1`. This makes the component 5 columns wide with a 1 column margin from the left at the medium breakpoint and higher.

**Single width Graphic component**
Add classes `col-md-4 margin-end-md-1`.  This makes the component 4 columns wide with a 1 column margin from the right at the medium breakpoint and higher.

The result for the above would look something like the following (gray block background color and guidelines added for illustrative purposes):

![margin-start-end](https://github.com/adaptlearning/adapt-contrib-vanilla/assets/898168/4699b905-710d-408e-9256-0322947483ba)

The number of columns + starting/ending margins must add up to the total number of columns (or less) which is 12 unless redefined in the theme.

### Additional work
The theme [wiki](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/Custom-Classes#columns) should be updated with these new classes.