### PR TITLE
Fix: Matching dropdown list style improvements (fixes #478)

### DIFF
--- a/less/plugins/adapt-contrib-matching/dropdown.less
+++ b/less/plugins/adapt-contrib-matching/dropdown.less
@@ -46,14 +46,15 @@
   border-bottom: 1px solid @item-color-hover;
   color: @item-color-inverted;
 
-  .no-touch &:not(:focus-visible):not([aria-selected="true"]):hover {
+  .no-touch &:not(:focus-visible):hover,
+  .dropdown__btn.is-selected + .dropdown__list &[aria-selected="true"]:hover {
     background-color: @item-color-hover;
     color: @item-color-inverted-hover;
     .transition(background-color @duration ease-in, color @duration ease-in;);
   }
 
   &:focus-visible,
-  &[aria-selected="true"] {
+  .dropdown__btn.is-selected + .dropdown__list &[aria-selected="true"] {
     // This code can be used to style a non-native dropdown as closely
     // as possible to the default browser settings
     // background-color: Highlight;

--- a/less/plugins/adapt-contrib-matching/dropdown.less
+++ b/less/plugins/adapt-contrib-matching/dropdown.less
@@ -40,11 +40,19 @@
   }
 }
 
+.dropdown__list {
+  border: 0.19rem solid @item-color-selected;
+}
+
 .dropdown-item {
   padding: @item-padding;
   background-color: @item-color;
   border-bottom: 1px solid @item-color-hover;
   color: @item-color-inverted;
+
+  &:last-child {
+    border-bottom: none;
+  }
 
   .no-touch &:not(:focus-visible):hover,
   .dropdown__btn.is-selected + .dropdown__list &[aria-selected="true"]:hover {


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-vanilla/issues/478

### Fix 1: Border applied to dropdown list to distinguish start/end of dropdown list.
For instances where the dropdown overlaps other question items. The border colour is the same as the `.dropdown__btn `expanded, `@item-color-selected`, to associate the list of options to the dropdown button.

![dropdown_border_applied_1](https://github.com/adaptlearning/adapt-contrib-vanilla/assets/7045330/4229a3c9-ecc1-4b18-b235-097b92a9d6a9)

![dropdown_border_applied_2](https://github.com/adaptlearning/adapt-contrib-vanilla/assets/7045330/a4462a94-ef9e-4ce3-bb10-ffab1960e783)

### Fix 2: Only apply selected styles when a dropdown item has been selected
The current styling applies the selected styles to the first item before a selection has been made. As this shares the same styles, `@item-color-selected` as `.dropdown__btn` the first item looks unavailable or already selected. See screen shots below.

Current styling when list expanded (selection yet to be made):
![before_item_selection-current](https://github.com/adaptlearning/adapt-contrib-vanilla/assets/7045330/902c7db5-fad6-40f3-b2cf-3ebbf57b5cc5)

This PR only applies selected styles when a dropdown item has been selected:
![before_item_selection-new-pr](https://github.com/adaptlearning/adapt-contrib-vanilla/assets/7045330/568681d4-5f57-4f9d-8286-d17a45a228cf)

![item_selected](https://github.com/adaptlearning/adapt-contrib-vanilla/assets/7045330/d843ffa1-ec2c-4750-a806-57e765f02bba)


