### PR TITLE
New: expand on Narrative progress indicator state styles (fixes #509)

### DIFF
--- a/less/plugins/adapt-contrib-narrative/narrative.less
+++ b/less/plugins/adapt-contrib-narrative/narrative.less
@@ -22,19 +22,19 @@
   &__progress {
     background-color: @item-color;
     color: @item-color-inverted;
-    border-color: @item-color;
+    border-color: @item-color-inverted;
     border-radius: 50%;
   }
 
   &__progress.is-visited {
     background-color: @visited;
     color: @visited-inverted;
-    border-color: @visited;
+    border-color: @visited-inverted;
   }
 
   &__progress.is-selected {
-    background-color: @item-color-inverted-selected;
-    color: @item-color-selected;
+    background-color: @item-color-selected;
+    color: @item-color-inverted-selected;
     border-color: @item-color-selected;
   }
 

--- a/less/plugins/adapt-contrib-narrative/narrative.less
+++ b/less/plugins/adapt-contrib-narrative/narrative.less
@@ -21,15 +21,21 @@
 
   &__progress {
     background-color: @item-color;
+    color: @item-color-inverted;
+    border-color: @item-color;
     border-radius: 50%;
   }
 
   &__progress.is-visited {
     background-color: @visited;
+    color: @visited-inverted;
+    border-color: @visited;
   }
 
   &__progress.is-selected {
-    background-color: @item-color-selected;
+    background-color: @item-color-inverted-selected;
+    color: @item-color-selected;
+    border-color: @item-color-selected;
   }
 
   &__strapline-btn {

--- a/less/project/theme-blocks.less
+++ b/less/project/theme-blocks.less
@@ -61,11 +61,38 @@
 
   .narrative {
     &__progress {
-      background-color: fade(@@color-inverted, 50%);
+      background-color: @@color-inverted;
+      color: @@color;
+      border-color: inherit;
     }
 
     &__progress.is-selected {
-      background-color: @@color-inverted;
+      background-color: @@color;
+      color: @@color-inverted;
+      border-color: @@color-inverted;
+    }
+  }
+
+  & when (@color = transparent-dark) {
+    .narrative {
+      &__progress {
+        background-color: darken(@@color-inverted, 50%);
+        color: @@color-inverted;
+        border-color: @@color;
+      }
+  
+      &__progress.is-selected  {
+        background-color: @@color-inverted;
+        color: darken(@@color-inverted, 50%);
+      }
+    }
+  }
+
+  & when (@color = transparent-light) {
+    .narrative {
+      &__progress {
+        color: @white;
+      }
     }
   }
 }

--- a/less/project/theme-blocks.less
+++ b/less/project/theme-blocks.less
@@ -61,14 +61,14 @@
 
   .narrative {
     &__progress {
-      background-color: @@color-inverted;
+      background-color: fade(@@color-inverted, 50%);
       color: @@color;
       border-color: inherit;
     }
 
     &__progress.is-selected {
-      background-color: @@color;
-      color: @@color-inverted;
+      background-color: @@color-inverted;
+      color: @@color;
       border-color: @@color-inverted;
     }
   }
@@ -90,7 +90,7 @@
 
   & when (@color = transparent-light) {
     .narrative {
-      &__progress {
+      &__progress, &__progress.is-selected {
         color: @white;
       }
     }

--- a/less/project/theme-common.less
+++ b/less/project/theme-common.less
@@ -42,14 +42,14 @@
 
   .narrative {
     &__progress {
-      background-color: @@color-inverted;
+      background-color: fade(@@color-inverted, 50%);
       color: @@color;
       border-color: inherit;
     }
 
     &__progress.is-selected {
-      background-color: @@color;
-      color: @@color-inverted;
+      background-color: @@color-inverted;
+      color: @@color;
       border-color: @@color-inverted;
     }
   }
@@ -71,7 +71,7 @@
 
   & when (@color = transparent-light) {
     .narrative {
-      &__progress {
+      &__progress, &__progress.is-selected {
         color: @white;
       }
     }

--- a/less/project/theme-common.less
+++ b/less/project/theme-common.less
@@ -42,11 +42,15 @@
 
   .narrative {
     &__progress {
-      background-color: fade(@@color-inverted, 50%);
+      background-color: @@color-inverted;
+      color: @@color;
+      border-color: inherit;
     }
 
     &__progress.is-selected {
-      background-color: @@color-inverted;
+      background-color: @@color;
+      color: @@color-inverted;
+      border-color: @@color-inverted;
     }
   }
 }

--- a/less/project/theme-common.less
+++ b/less/project/theme-common.less
@@ -53,6 +53,29 @@
       border-color: @@color-inverted;
     }
   }
+
+  & when (@color = transparent-dark) {
+    .narrative {
+      &__progress {
+        background-color: darken(@@color-inverted, 50%);
+        color: @@color-inverted;
+        border-color: @@color;
+      }
+  
+      &__progress.is-selected  {
+        background-color: @@color-inverted;
+        color: darken(@@color-inverted, 50%);
+      }
+    }
+  }
+
+  & when (@color = transparent-light) {
+    .narrative {
+      &__progress {
+        color: @white;
+      }
+    }
+  }
 }
 
 }


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-vanilla/issues/509

### New
* Narrative progress indicator `color` and `border-color` styles added to support [Narrative PR: completion icon added to progress indicators](https://github.com/adaptlearning/adapt-contrib-narrative/pull/301).
* `background-color` values remain the same for backwards compatibility (pre PR iterations of the plugin where the `border` property isn't defined).
<img width="73" alt="standard" src="https://github.com/adaptlearning/adapt-contrib-vanilla/assets/7045330/cfaa8c70-ba57-4786-809f-b1c2588d268b">

### Update
 * `bg-color` mixin updated to include `color` and `border-color` styles. 
 * `bg-color` mixin `transparent-dark` and `transparent-light` conditions added to ensure a [minimum contrast ratio of 3:1](https://www.w3.org/WAI/WCAG21/Techniques/general/G207#:~:text=The%20first%20test%20of%20the,it%20passes%20the%20success%20criterion.).
 *  Legacy `block-color` mixin updated as per `bg-color` mixin.

### Testing
For testing completion icons, please install [Narrative issue/288 branch](https://github.com/adaptlearning/adapt-contrib-narrative/tree/issue/288).

For testing backwards compatibility, please install Narrative master branch.

In _block.json_, test the `bg-color` mixin applying color classes to a block containing a Narrative. Using either the Vanilla classes below or create your own.

`"_classes": "bg-color black"`
<img width="77" alt="bg-color_black" src="https://github.com/adaptlearning/adapt-contrib-vanilla/assets/7045330/bcb092a5-a387-40c4-aa6f-1a4b0eadeaf2">

`"_classes": "bg-color white"`
<img width="76" alt="bg-color_white" src="https://github.com/adaptlearning/adapt-contrib-vanilla/assets/7045330/8ea70834-2ef4-4153-aceb-0525342c4f2f">

`"_classes": "bg-color transparent-dark"` (intended for application over a dark background image)
<img width="80" alt="bg-color_transparent-dark" src="https://github.com/adaptlearning/adapt-contrib-vanilla/assets/7045330/79efe6a7-5f03-49fc-9536-c78e96e513f0">




