### PR TITLE
Fix: Add hover effect to GMCQ items to match MCQ items (fixes #513)

### DIFF
--- a/less/plugins/adapt-contrib-gmcq/gmcq.less
+++ b/less/plugins/adapt-contrib-gmcq/gmcq.less
@@ -1,6 +1,10 @@
 .gmcq-item {
   &__label {
     margin: @item-margin;
+
+    .no-touch &:not(.is-disabled):not(.is-selected):hover .gmcq-item__icon {
+      .effect-scalePulse;
+    }
   }
 
   &__option {


### PR DESCRIPTION
Fixes #513 

### Fix
* Adds the [MCQ item hover effect](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/1d90e97fbafc75a095a6291073d0c31b3fd659ec/less/plugins/adapt-contrib-mcq/mcq.less#L15) to GMCQ items

### Testing
1. Hover over an GMCQ item
2. It should animate similar to MCQ items. In other words, the radio or checkbox should have a pulse animation.
