### PR TITLE
Fix: Add menu subtitle color variable (fixes #515)

### DIFF
--- a/less/_defaults/_colors.less
+++ b/less/_defaults/_colors.less
@@ -89,6 +89,7 @@
 // --------------------------------------------------
 @menu-header-background-color: transparent;
 @menu-header-title-color: @heading-color;
+@menu-header-subtitle-color: @heading-color;
 @menu-header-body-color: @font-color;
 @menu-header-instruction-color: @font-color;
 

--- a/less/plugins/adapt-contrib-boxmenu/boxMenu.less
+++ b/less/plugins/adapt-contrib-boxmenu/boxMenu.less
@@ -48,6 +48,7 @@
   &__subtitle {
     margin-bottom: @menu-subtitle-margin;
     .menu-subtitle;
+    color: @menu-header-subtitle-color;
   }
 
   &__body {

--- a/properties.schema
+++ b/properties.schema
@@ -287,6 +287,12 @@
             "inputType": "ColourPicker",
             "default": ""
           },
+          "menu-header-subtitle-color": {
+            "title": "Menu header subtitle colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": ""
+          },
           "menu-header-body-color": {
             "title": "Menu header body colour",
             "type": "string",

--- a/schema/theme.schema.json
+++ b/schema/theme.schema.json
@@ -279,6 +279,12 @@
           "default": "",
           "_backboneForms": "ColourPicker"
         },
+        "menu-header-subtitle-color": {
+          "type": "string",
+          "title": "Menu header subtitle colour",
+          "default": "",
+          "_backboneForms": "ColourPicker"
+        },
         "menu-header-body-color": {
           "type": "string",
           "title": "Menu header body colour",


### PR DESCRIPTION
Fixes #515 

### Fix
* Adds the `@menu-header-subtitle-color` variable to control the menu subtitle color

### Testing
1. In _course.json_, add a `subtitle` property

```
  "title": "Adapt v5",
  "displayTitle": "Adapt Version 5",
  "subtitle": "Subtitle lorem ipsum",
```

2. In your theme, change the `@menu-header-subtitle-color` value.