### PR TITLE
Fix: Add variables to control box menu item padding (fixes #506)

### DIFF
--- a/less/_defaults/_spacing-containers.less
+++ b/less/_defaults/_spacing-containers.less
@@ -26,6 +26,9 @@
 @menu-item-padding-ver: 1rem;
 @menu-item-padding-hoz: .5rem;
 
+@menu-item-inner-padding-ver: 1rem;
+@menu-item-inner-padding-hoz: 1rem;
+
 @menu-item-container-margin: 1.5rem;
 
 // Page container and header padding

--- a/less/plugins/adapt-contrib-boxmenu/boxMenuItem.less
+++ b/less/plugins/adapt-contrib-boxmenu/boxMenuItem.less
@@ -4,7 +4,7 @@
   &__inner {
     width: 100%;
     margin: 0 @menu-item-padding-hoz @menu-item-padding-ver;
-    padding: 1rem;
+    padding: @menu-item-inner-padding-ver @menu-item-inner-padding-hoz;
     background-color: @menu-item;
     color: @menu-item-inverted;
     border: 1px solid @menu-item-border-color;


### PR DESCRIPTION
Fix #506 

### Fix
* Add `@menu-item-inner-padding-ver` and `@menu-item-inner-padding-horz` variables to control box menu item padding
