### PR TITLE
Update: Boxmenu item graphic margin to support latest template amends (fixes #520)

### DIFF
--- a/less/plugins/adapt-contrib-boxmenu/boxMenuItem.less
+++ b/less/plugins/adapt-contrib-boxmenu/boxMenuItem.less
@@ -11,8 +11,8 @@
     border-radius: @item-border-radius;
   }
 
-  &__image-container {
-    margin-bottom: @menu-item-image-margin;
+  &__image-container + &__details {
+    margin-top: @menu-item-image-margin;
   }
 
   &__title {


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-vanilla/issues/520

### Fix
* Apply margin to `.boxmenu-item__details` instead of `.boxmenu-item__image-container`. No visual change to the menu item spacing, just the application. When no image exists, margin isn't applied.

### Testing
Please test with both Boxmenu master branch and [issue/198](https://github.com/adaptlearning/adapt-contrib-boxMenu/tree/issue/198).



