### PR TITLE
Fix: restore matching dropdown options focus/selected highlight (fixes #525)

### DIFF
--- a/less/plugins/adapt-contrib-matching/dropdown.less
+++ b/less/plugins/adapt-contrib-matching/dropdown.less
@@ -54,15 +54,14 @@
     border-bottom: none;
   }
 
-  .no-touch &:not(:focus-visible):hover,
-  .dropdown__btn.is-selected + .dropdown__list &[aria-selected="true"]:hover {
+  .no-touch &:not(:focus-visible):not([aria-selected="true"]):hover {
     background-color: @item-color-hover;
     color: @item-color-inverted-hover;
     .transition(background-color @duration ease-in, color @duration ease-in;);
   }
 
   &:focus-visible,
-  .dropdown__btn.is-selected + .dropdown__list &[aria-selected="true"] {
+  &[aria-selected="true"] {
     // This code can be used to style a non-native dropdown as closely
     // as possible to the default browser settings
     // background-color: Highlight;


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-vanilla/issues/525
Fixes https://github.com/adaptlearning/adapt-contrib-matching/issues/193

### Fix
* Restore matching dropdown options focus/selected highlight for keyboard users.
* Issue introduced during previous PR (Fix 2): https://github.com/adaptlearning/adapt-contrib-vanilla/pull/507

### Testing
- _Tab_ to a Matching component, select _Enter_ to expand the dropdown button.
- Use _up_ / _down_ arrows to navigate between the options. 
- Use _spacebar_ to select an option.

The option receiving focus should be highlighted.
The selected option should be highlighted.



