### PR TITLE
New: Added gmcq support for _canShowCorrectness

### DIFF
--- a/less/plugins/adapt-contrib-gmcq/gmcq.less
+++ b/less/plugins/adapt-contrib-gmcq/gmcq.less
@@ -41,3 +41,16 @@
     text-align: center;
   }
 }
+
+.gmcq:not(.can-show-correctness) {
+  .gmcq-item__option {
+    position: relative;
+  }
+
+  .gmcq-item__state-correctness {
+    position: absolute;
+    top: @item-padding / 2;
+    left: 0;
+    right: 0;
+  }
+}


### PR DESCRIPTION
part of https://github.com/adaptlearning/adapt_framework/issues/3597

### New
* Added support for _canShowCorrectness
* When "_canShowMarking": true and "_canShowCorrectness": false, position marking state over selection state for consistency with mcq