### PR TITLE
Update: Remove AAT note (fix #535)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 * A sentence describing each fix
 
 ### Update
-* A sentence describing each udpate
+* A sentence describing each update
 
 ### New
 * A sentence describing each new feature

--- a/less/_defaults/_colors.less
+++ b/less/_defaults/_colors.less
@@ -13,11 +13,6 @@
 @transparent-light: transparent;
 @transparent-dark: transparent;
 
-// Note: If customising a theme for the Authoring Tool please update the
-// corresponding default value for that variable in the properties.schema file.
-// This is to stop any amended variables below being overwritten by
-// the Theme Picker in the Authoring Tool.
-
 // Body, link, and heading colour
 // --------------------------------------------------
 @body-background-color: @white;


### PR DESCRIPTION
Fix #535 

### Update
* Removes AAT-related note in `_colors.less` as it is no longer needed:

> // Note: If customising a theme for the Authoring Tool please update the
> // corresponding default value for that variable in the properties.schema file.
> // This is to stop any amended variables below being overwritten by
> // the Theme Picker in the Authoring Tool.

### Fix
* Fix typo in PR template