### PR TITLE
Fix: Add article to bg-color mixin (fix #539)

### DIFF
--- a/less/project/theme-common.less
+++ b/less/project/theme-common.less
@@ -19,6 +19,7 @@
   background-color: @@color;
   color: @@color-inverted;
 
+  .article,
   .block,
   .component {
     &__title,


### PR DESCRIPTION
Fixes #539 

### Fix
* Adds article to the `bg-color` mixin

### Testing
1. Add a `bg-color` class to an article
2. Add `displayTitle`, `body`, and `instruction` values to the article

### Expected behaviour
Text colors should be changed in the article header text