### PR TITLE
Update: Apply @progress-border-radius to PLP indicator inner (fixes #547)

### DIFF
--- a/less/plugins/adapt-contrib-pageLevelProgress/pageLevelProgressIndicator.less
+++ b/less/plugins/adapt-contrib-pageLevelProgress/pageLevelProgressIndicator.less
@@ -14,6 +14,7 @@
   }
 
   &__indicator-inner {
+    border-radius: @progress-border-radius;
     background-color: @progress-inverted;
   }
 


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-vanilla/issues/547

### Update
* Apply `@progress-border-radius` to PLP indicator inner. 

### Testing
1. Change `@progress-border-radius` to `0`.
2. Review PLP indicators in your course. The curve should be removed from the indicator outer border and the inner bar.

Default 50px value:
![Image](https://github.com/user-attachments/assets/49cffb20-dd4c-4b67-a8a2-adc463ecab58)

Changing `@progress-border-radius` to `0` should look like this:
![Image](https://github.com/user-attachments/assets/7e816a31-3f54-4ffd-ae67-66ae8056e93d)

Instead of this:
![Image](https://github.com/user-attachments/assets/36f10d9c-dfc7-412b-bbc2-6e1b565b555d)


