### PR TITLE
New: Add bounceUpOnce and bounceDownOnce animation Less mixins (fix #561)

### DIFF
--- a/less/_defaults/_animations.less
+++ b/less/_defaults/_animations.less
@@ -122,6 +122,32 @@
   // name, duration, delay, iteration count, direction, timing-function, fill mode
 }
 
+// bounceUpOnce animation
+// --------------------------------------------------
+.effect-bounceUpOnce() {
+  .keyframes(bounceUpOnce; {
+    0% { transform: translateY(0); }
+    50% { transform: translateY(-5px); }
+    100% { transform: translateY(0); }
+  });
+
+  .animation(bounceUpOnce 0.5s 0s 1 normal ease-in-out none);
+  // name, duration, delay, iteration count, direction, timing-function, fill mode
+}
+
+// bounceDownOnce animation
+// --------------------------------------------------
+.effect-bounceDownOnce() {
+  .keyframes(bounceDownOnce; {
+    0% { transform: translateY(0); }
+    50% { transform: translateY(5px); }
+    100% { transform: translateY(0); }
+  });
+
+  .animation(bounceDownOnce 0.5s 0s 1 normal ease-in-out none);
+  // name, duration, delay, iteration count, direction, timing-function, fill mode
+}
+
 // 360 spin animation
 // --------------------------------------------------
 .effect-spin() {


### PR DESCRIPTION
Fix #561 

### New
* Adds `bounceUpOnce()` and `bounceDownOnce()` animation Less mixins

### Testing
Add to a Trickle when showing an icon on the button.

Less
```
.no-touch .trickle__btn:not(.is-disabled):hover .icon::before {
  .effect-bounceDownOnce;
}
```

Trickle config:
```
"_trickle": {
  "_isEnabled": true,
  "_button": {
      "_isEnabled": true,
      "_styleBeforeCompletion": "visible",
      "_isFullWidth": true,
      "_hasIcon": true
  }
},
```