### PR TITLE
Fix: Add missing _color.less variables to schemas (fixes #542)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -64,6 +64,13 @@
             "inputType": "ColourPicker",
             "default": "",
             "help": "Global title colour inverted. Either a lightened / darkened alternative to Title colour."
+          },
+          "body-background-color": {
+            "title": "Body background colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "The background colour of the main body element."
           }
         }
       },
@@ -1001,6 +1008,13 @@
             "default": "",
             "help": "Defines the drawer item text / icon colour when selected. Should be a colour that provides good contrast against the drawer item selected colour."
           },
+          "drawer-item-selected-underline": {
+            "title": "Drawer item colour - selected underline",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "Defines the colour of the underline that appears beneath the selected drawer item."
+          },
           "drawer-item-locked": {
             "title": "Drawer item background colour - locked",
             "type": "string",
@@ -1059,6 +1073,33 @@
         }
       },
 
+      "_pullQuote": {
+        "type": "object",
+        "required": false,
+        "title": "Pull Quote",
+        "properties": {
+          "pull-quote": {
+            "title": "Pull quote background colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": ""
+          },
+          "pull-quote-inverted": {
+            "title": "Pull quote text colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "The text colour for pull quote elements. Should provide good contrast against the pull quote background colour."
+          },
+          "pull-quote-border": {
+            "title": "Pull quote border colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": ""
+          }
+        }
+      },
+
       "_misc": {
         "type": "object",
         "required": false,
@@ -1091,6 +1132,13 @@
             "default": "",
             "help": "Defines the shadow text / icon colour. Should be a colour that provides good contrast against the shadow colour."
           },
+          "shadow-opacity": {
+            "title": "Shadow opacity",
+            "type": "string",
+            "inputType": "Text",
+            "default": "",
+            "help": "The opacity of the shadow overlay used behind loading indicators and popups. Accepts a percentage value e.g. 50%."
+          },
           "loading": {
             "title": "Loading animation background colour",
             "type": "string",
@@ -1103,6 +1151,27 @@
             "inputType": "ColourPicker",
             "default": "",
             "help": "Defines the loading animation bar colour. Should be a colour that provides good contrast against the loading colour."
+          }
+        }
+      },
+
+      "_tooltip": {
+        "type": "object",
+        "required": false,
+        "title": "Tooltip",
+        "properties": {
+          "tooltip-color": {
+            "title": "Tooltip background colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": ""
+          },
+          "tooltip-text-color": {
+            "title": "Tooltip text colour",
+            "type": "string",
+            "inputType": "ColourPicker",
+            "default": "",
+            "help": "The text colour for tooltip elements. Should provide good contrast against the tooltip background colour."
           }
         }
       }

--- a/schema/theme.schema.json
+++ b/schema/theme.schema.json
@@ -62,6 +62,13 @@
           "description": "Global title colour inverted. Either a lightened / darkened alternative to Title colour.",
           "default": "",
           "_backboneForms": "ColourPicker"
+        },
+        "body-background-color": {
+          "type": "string",
+          "title": "Body background colour",
+          "description": "The background colour of the main body element.",
+          "default": "",
+          "_backboneForms": "ColourPicker"
         }
       }
     },
@@ -1000,6 +1007,13 @@
           "default": "",
           "_backboneForms": "ColourPicker"
         },
+        "drawer-item-selected-underline": {
+          "type": "string",
+          "title": "Drawer item colour - selected underline",
+          "description": "Defines the colour of the underline that appears beneath the selected drawer item.",
+          "default": "",
+          "_backboneForms": "ColourPicker"
+        },
         "drawer-item-locked": {
           "type": "string",
           "title": "Drawer item background colour - locked",
@@ -1058,6 +1072,33 @@
       }
     },
 
+    "_pullQuote": {
+      "type": "object",
+      "title": "Pull Quote",
+      "default": {},
+      "properties": {
+        "pull-quote": {
+          "type": "string",
+          "title": "Pull quote background colour",
+          "default": "",
+          "_backboneForms": "ColourPicker"
+        },
+        "pull-quote-inverted": {
+          "type": "string",
+          "title": "Pull quote text colour",
+          "description": "The text colour for pull quote elements. Should provide good contrast against the pull quote background colour.",
+          "default": "",
+          "_backboneForms": "ColourPicker"
+        },
+        "pull-quote-border": {
+          "type": "string",
+          "title": "Pull quote border colour",
+          "default": "",
+          "_backboneForms": "ColourPicker"
+        }
+      }
+    },
+
     "_misc": {
       "type": "object",
       "title": "Miscellaneous",
@@ -1090,6 +1131,12 @@
           "default": "",
           "_backboneForms": "ColourPicker"
         },
+        "shadow-opacity": {
+          "type": "string",
+          "title": "Shadow opacity",
+          "description": "The opacity of the shadow overlay used behind loading indicators and popups. Accepts a percentage value e.g. 50%.",
+          "default": ""
+        },
         "loading": {
           "type": "string",
           "title": "Loading animation background colour",
@@ -1100,6 +1147,27 @@
           "type": "string",
           "title": "Loading animation colour - inverted",
           "description": "Defines the loading animation bar colour. Should be a colour that provides good contrast against the loading colour.",
+          "default": "",
+          "_backboneForms": "ColourPicker"
+        }
+      }
+    },
+
+    "_tooltip": {
+      "type": "object",
+      "title": "Tooltip",
+      "default": {},
+      "properties": {
+        "tooltip-color": {
+          "type": "string",
+          "title": "Tooltip background colour",
+          "default": "",
+          "_backboneForms": "ColourPicker"
+        },
+        "tooltip-text-color": {
+          "type": "string",
+          "title": "Tooltip text colour",
+          "description": "The text colour for tooltip elements. Should provide good contrast against the tooltip background colour.",
           "default": "",
           "_backboneForms": "ColourPicker"
         }


### PR DESCRIPTION
Fixes #542

### Fix
* Added 8 missing LESS colour variables to both `schema/theme.schema.json` (modern, draft 2020-12) and `properties.schema` (legacy, draft-04)

**Variables added from issue #542:**
* `body-background-color` — added to `_global` section
* `drawer-item-selected-underline` — added to `_drawer` section
* `pull-quote`, `pull-quote-inverted`, `pull-quote-border` — added in new `_pullQuote` section
* `shadow-opacity` — added to `_misc` section (as text input, not colour picker, since it accepts a percentage value e.g. `50%`)

**Additional missing variables identified during review:**
* `tooltip-color`, `tooltip-text-color` — added in new `_tooltip` section

### Testing
1. Load the course in the Adapt Authoring Tool
2. Navigate to Theme settings → Colours
3. Verify the following new fields appear in their respective sections:
   - **Global**: Body background colour
   - **Drawer**: Drawer item colour - selected underline
   - **Pull Quote** (new section): Pull quote background colour, Pull quote text colour, Pull quote border colour
   - **Miscellaneous**: Shadow opacity (text input)
   - **Tooltip** (new section): Tooltip background colour, Tooltip text colour
4. Set values for each and confirm they override the corresponding LESS variables in the built output