### PR TITLE
New: Improve styles when prefixes / suffixes are present (fixes #591)

### DIFF
--- a/less/plugins/adapt-contrib-slider/slider.less
+++ b/less/plugins/adapt-contrib-slider/slider.less
@@ -41,7 +41,7 @@
         width: auto;
         min-width: 2.5rem;
         padding: 0 0.5rem;
-        border-radius: 1.25rem;
+        border-radius: @item-ui-border-radius;
       }
     }
   }

--- a/less/plugins/adapt-contrib-slider/slider.less
+++ b/less/plugins/adapt-contrib-slider/slider.less
@@ -3,6 +3,9 @@
 
 @slider-track-height: .375rem;
 
+// Min width to show prefix/suffix affixes on scale step numbers
+@slider-affix-breakpoint: @device-width-medium;
+
 .slider {
   // Numbers
   &__number-container {
@@ -31,20 +34,31 @@
     border-radius: 50%;
   }
 
-  // Lozenge shape when prefix or suffix is present
-  &__widget {
-    &.has-scale-step-prefix,
-    &.has-scale-step-suffix {
-      .slider__number,
-      .slider__number-selection,
-      .slider__number-model-answer {
-        width: auto;
-        min-width: 2.5rem;
-        padding: 0 0.5rem;
-        border-radius: @item-ui-border-radius;
-        white-space: nowrap;
-        line-height: normal;
+  @media (min-width: @slider-affix-breakpoint) {
+    // Lozenge shape when prefix or suffix is present
+    &__widget {
+      &.has-scale-step-prefix,
+      &.has-scale-step-suffix {
+        .slider__number,
+        .slider__number-selection,
+        .slider__number-model-answer {
+          width: auto;
+          min-width: 2.5rem;
+          padding: 0 0.5rem;
+          border-radius: @item-ui-border-radius;
+          white-space: nowrap;
+          line-height: normal;
+        }
       }
+    }
+  }
+
+  &__scale-step-prefix,
+  &__scale-step-suffix {
+    display: none;
+
+    @media (min-width: @slider-affix-breakpoint) {
+      display: inline;
     }
   }
 

--- a/less/plugins/adapt-contrib-slider/slider.less
+++ b/less/plugins/adapt-contrib-slider/slider.less
@@ -42,6 +42,7 @@
         min-width: 2.5rem;
         padding: 0 0.5rem;
         border-radius: @item-ui-border-radius;
+        white-space: nowrap;
       }
     }
   }

--- a/less/plugins/adapt-contrib-slider/slider.less
+++ b/less/plugins/adapt-contrib-slider/slider.less
@@ -32,16 +32,18 @@
   }
 
   // Lozenge shape when prefix or suffix is present
-  &__widget.has-scale-step-prefix &__number,
-  &__widget.has-scale-step-prefix &__number-selection,
-  &__widget.has-scale-step-prefix &__number-model-answer,
-  &__widget.has-scale-step-suffix &__number,
-  &__widget.has-scale-step-suffix &__number-selection,
-  &__widget.has-scale-step-suffix &__number-model-answer {
-    width: auto;
-    min-width: 2.5rem;
-    padding: 0 0.5rem;
-    border-radius: 1.25rem;
+  &__widget {
+    &.has-scale-step-prefix,
+    &.has-scale-step-suffix {
+      .slider__number,
+      .slider__number-selection,
+      .slider__number-model-answer {
+        width: auto;
+        min-width: 2.5rem;
+        padding: 0 0.5rem;
+        border-radius: 1.25rem;
+      }
+    }
   }
 
   // Scale

--- a/less/plugins/adapt-contrib-slider/slider.less
+++ b/less/plugins/adapt-contrib-slider/slider.less
@@ -43,6 +43,7 @@
         padding: 0 0.5rem;
         border-radius: @item-ui-border-radius;
         white-space: nowrap;
+        line-height: normal;
       }
     }
   }

--- a/less/plugins/adapt-contrib-slider/slider.less
+++ b/less/plugins/adapt-contrib-slider/slider.less
@@ -31,6 +31,19 @@
     border-radius: 50%;
   }
 
+  // Lozenge shape when prefix or suffix is present
+  &__widget.has-scale-step-prefix &__number,
+  &__widget.has-scale-step-prefix &__number-selection,
+  &__widget.has-scale-step-prefix &__number-model-answer,
+  &__widget.has-scale-step-suffix &__number,
+  &__widget.has-scale-step-suffix &__number-selection,
+  &__widget.has-scale-step-suffix &__number-model-answer {
+    width: auto;
+    min-width: 2.5rem;
+    padding: 0 0.5rem;
+    border-radius: 1.25rem;
+  }
+
   // Scale
   &__scale-container {
     background-color: lighten(@black, 75%);


### PR DESCRIPTION
Fixes #591

Depends on adaptlearning/adapt-contrib-slider#234

### New
* When `.has-scale-step-prefix` or `.has-scale-step-suffix` is present, scale labels switch to a lozenge (pill) shape
* The default circle style is unchanged. Only sliders with a configured prefix or suffix are affected.

<img width="600" alt="Slider" src="https://github.com/user-attachments/assets/420f46d3-7911-437a-aa99-a252a2030202" />

### Known issues
1. When scaleStepPrefix or scaleStepSuffix are configured, the first and last scale labels may extend beyond the edges of the slider widget, as the lozenge is wider than the original circle. This is expected since the amount of additional space needed depends on the length of the prefix/suffix strings.

<img width="200" alt="Screenshot 2026-04-01 at 2 16 17 PM" src="https://github.com/user-attachments/assets/94829dc8-3d45-434f-8f1e-05d4c893a074" />

The recommended fix is to add horizontal padding or margin to .slider__widget (or scope it to .slider__widget.has-scale-step-prefix / .has-scale-step-suffix) in a course-specific or custom theme override.

```css
// Adjust slider widget when affixes are present
.slider__widget.has-scale-step-suffix,
.slider__widget.has-scale-step-prefix {
  @media (min-width: @slider-affix-breakpoint) {
    margin: 0 1rem;
  }
}
```


### Testing
1. Configure a slider with `scaleStepPrefix` (e.g. `$`) and/or `scaleStepSuffix` (e.g. ` days`)
2. Verify scale labels render as lozenges (pill shape) with the prefix/suffix content fitting inside
3. Verify a slider without prefix or suffix still renders labels as circles
4. Verify the selected value indicator and correct answer indicator also use the lozenge shape when prefix/suffix are set
5. Test in both LTR and RTL layouts



Posted via collaboration with Claude Code