### PR TITLE
New: Expand header-color mixin to articles and blocks, add prefixed colors (fix #595)

### DIFF
--- a/less/project/theme-common.less
+++ b/less/project/theme-common.less
@@ -81,6 +81,45 @@
 
 }
 
+// Header color mixin
+// Add to menu/page/article/block to enable
+// e.g. 'header-color transparent-dark'
+// Note: both arguments must be predefined variables
+// --------------------------------------------------
+.header-color-mixin(black, white);
+.header-color-mixin(background, background-inverted);
+.header-color-mixin(transparent-light, font-color);
+.header-color-mixin(transparent-dark, font-color-inverted);
+
+.header-color-mixin(@color, @color-inverted) {
+
+.header-color.@{color} {
+  .menu,
+  .page,
+  .article,
+  .block {
+    &__header {
+      background-color: @@color;
+    }
+  }
+
+  .menu,
+  .page,
+  .article,
+  .block {
+    &__title,
+    &__subtitle,
+    &__body,
+    &__body a,
+    &__instruction,
+    &__instruction a {
+      color: @@color-inverted;
+    }
+  }
+}
+
+}
+
 // styles associated with _textAlignment property
 // --------------------------------------------------
 .text-align-mixin(page);

--- a/less/project/theme-common.less
+++ b/less/project/theme-common.less
@@ -4,7 +4,7 @@
 
 // Background color mixin
 // Can be added to course, contentObject, article, block, or component to enable
-// e.g. 'bg-color black'
+// e.g. 'bg-color black' or 'bg-color bg-black' (prefixed, safe to combine with header-color)
 // Note: both arguments must be predefined variables
 // --------------------------------------------------
 .bg-color-mixin(black, white);
@@ -15,7 +15,8 @@
 
 .bg-color-mixin(@color, @color-inverted) {
 
-.bg-color.@{color} {
+.bg-color.@{color},
+.bg-color.bg-@{color} {
   background-color: @@color;
   color: @@color-inverted;
 
@@ -83,7 +84,7 @@
 
 // Header color mixin
 // Add to menu/page/article/block to enable
-// e.g. 'header-color transparent-dark'
+// e.g. 'header-color transparent-dark' or 'header-color header-transparent-dark' (prefixed, safe to combine with bg-color)
 // Note: both arguments must be predefined variables
 // --------------------------------------------------
 .header-color-mixin(black, white);
@@ -93,7 +94,8 @@
 
 .header-color-mixin(@color, @color-inverted) {
 
-.header-color.@{color} {
+.header-color.@{color},
+.header-color.header-@{color} {
   &.menu .menu,
   &.page .page,
   &.article .article,

--- a/less/project/theme-common.less
+++ b/less/project/theme-common.less
@@ -100,6 +100,18 @@
   &.block .block {
     &__header {
       background-color: @@color;
+
+      .pagelevelprogress {
+        &__indicator {
+          border-color: @@color-inverted;
+        }
+        &__indicator-inner {
+          background-color: @@color;
+        }
+        &__indicator-bar {
+          background-color: @@color-inverted;
+        }
+      }
     }
 
     &__title,

--- a/less/project/theme-common.less
+++ b/less/project/theme-common.less
@@ -94,19 +94,14 @@
 .header-color-mixin(@color, @color-inverted) {
 
 .header-color.@{color} {
-  .menu,
-  .page,
-  .article,
-  .block {
+  &.menu .menu,
+  &.page .page,
+  &.article .article,
+  &.block .block {
     &__header {
       background-color: @@color;
     }
-  }
 
-  .menu,
-  .page,
-  .article,
-  .block {
     &__title,
     &__subtitle,
     &__body,

--- a/less/project/theme-contentObjects.less
+++ b/less/project/theme-contentObjects.less
@@ -15,38 +15,3 @@
 .hide-page-header .page__header {
   .u-display-none;
 }
-
-// Header color mixin
-// Add to menu/page to enable
-// e.g. 'header-color transparent-dark'
-// Note: both arguments must be predefined variables
-// --------------------------------------------------
-.header-color-mixin(black, white);
-.header-color-mixin(background, background-inverted);
-.header-color-mixin(transparent-light, font-color);
-.header-color-mixin(transparent-dark, font-color-inverted);
-
-.header-color-mixin(@color, @color-inverted) {
-
-.header-color.@{color} {
-  .menu,
-  .page {
-    &__header {
-      background-color: @@color;
-    }
-  }
-
-  .menu,
-  .page {
-    &__title,
-    &__subtitle,
-    &__body,
-    &__body a,
-    &__instruction,
-    &__instruction a {
-      color: @@color-inverted;
-    }
-  }
-}
-
-}


### PR DESCRIPTION
Fix #595 

### New
* Expand `header-color mixin` to article and block headers
* Add prefixed color class options to `header-color` and `bg-color` mixins. This allows both classes to be used without conflict on a single article or block.

### Testing
1. **Header color:** Add `header-color black` to an article or block with header text. The header background should be black with white text. 

2. **Header color + element color:** Add `header-color header-black` and `bg-color blue` to an article or block with header text. The header background should be black with white text while the rest of the article/block should be blue with white text.  Note that you will need to create a bg-color class for blue with `.bg-color-mixin(blue, white);`