### PR TITLE
Fix: Adjust block container only when containing a block with a column class (fix #597)

### DIFF
--- a/less/project/columns.less
+++ b/less/project/columns.less
@@ -17,7 +17,7 @@
 
     // Additional styles required to extend column layout support to blocks
     // for consistency with component column styles in core/less/core/component.less
-    .block__container:has(.col-@{size}-@{iteration}) {
+    .block__container:has(.block.col-@{size}-@{iteration}) {
       width: 100%;
       display: flex;
       flex-direction: column;
@@ -32,14 +32,14 @@
 
     
     // Contain width of child blocks to 70rem (1120px), inline with default content width
-    .article .block__container:has(.col-@{size}-@{iteration}) {
+    .article .block__container:has(.block.col-@{size}-@{iteration}) {
       .l-container-responsive(@max-content-width);
     }
 
     // Optional article class 'extend-container'
     // Extend width of child blocks to max page width
     // --------------------------------------------------
-    .article.extend-container .block__container:has(.col-@{size}-@{iteration}) {
+    .article.extend-container .block__container:has(.block.col-@{size}-@{iteration}) {
       max-width: @max-page-width;
     }
   }


### PR DESCRIPTION
Fix #597 

### Fix
* Adjust block container only when containing a _block_ with a column class. Adding a column class to a _component_ alone should not affect the block container width.

### Testing (use case 1)
Test using column classes on components.

1. Create a block with a single width Text and Graphic component.
2. Add `bg-color black` to the block
3. Add `col-md-4` to the Graphic component

### Expected results
The black block background should continue to span 100% of the page width.

<img width="500" alt="fw" src="https://github.com/user-attachments/assets/33aaa6ef-1b92-43b7-b938-113ae7ad61bb" />


### Testing (use case 2)
Test that the new block column classes still work as expected.

1. Add `col-md-8` to a block
2. Add `bg-color black` to the block

### Expected results
Block container should be content width rather than full page width. The actual block itself should be 8 columns wide.

<img width="500" alt="block" src="https://github.com/user-attachments/assets/024ce167-6cf2-40a8-96f3-3af87660db96" />
