### PR TITLE
Fix: Resources header padding and styles (fix #599)

### DIFF
--- a/less/_defaults/_font-config.less
+++ b/less/_defaults/_font-config.less
@@ -254,6 +254,14 @@
 
 // Drawer
 // --------------------------------------------------
+@drawer-title-size: 1.5rem;
+@drawer-title-family: @title-family;
+@drawer-title-weight: @font-weight-regular;
+@drawer-title-line-height: @title-line-height;
+@drawer-title-mobile-percentage: .75;
+@drawer-title-letter-spacing: normal;
+@drawer-title-text-transform: none;
+
 @drawer-item-title-size: 1rem;
 @drawer-item-title-family: @title-family;
 @drawer-item-title-weight: @font-weight-regular;

--- a/less/_defaults/_font-mixins.less
+++ b/less/_defaults/_font-mixins.less
@@ -278,6 +278,19 @@ strong {
 
 // Drawer
 // --------------------------------------------------
+.drawer-title() {
+  font-family: @drawer-title-family;
+  font-size: @drawer-title-size * @drawer-title-mobile-percentage;
+  font-weight: @drawer-title-weight;
+  line-height: @drawer-title-line-height;
+  letter-spacing: @drawer-title-letter-spacing;
+  text-transform: @drawer-title-text-transform;
+
+  @media (min-width: @device-width-medium) {
+    font-size: @drawer-title-size;
+  }
+}
+
 .drawer-item-title() {
   font-family: @drawer-item-title-family;
   font-size: @drawer-item-title-size;

--- a/less/_defaults/_spacing-config.less
+++ b/less/_defaults/_spacing-config.less
@@ -124,3 +124,9 @@
 // --------------------------------------------------
 @drawer-title-margin: 0.25rem;
 @drawer-body-margin: 0;
+
+// Drawer header text margin
+// --------------------------------------------------
+@drawer-header-title-margin: 1rem;
+@drawer-header-body-margin: 1rem;
+@drawer-header-instruction-margin: 0;

--- a/less/plugins/adapt-contrib-resources/resources.less
+++ b/less/plugins/adapt-contrib-resources/resources.less
@@ -1,4 +1,9 @@
 .resources {
+  &__header {
+    padding: @drawer-item-padding-ver @drawer-item-padding-hoz;
+    border-bottom: 1px solid @drawer-item-hover;
+  }
+
   &__filter-btn {
     padding: @item-padding (@item-padding / 2);
     .resources-filter-btn;

--- a/less/plugins/adapt-contrib-resources/resources.less
+++ b/less/plugins/adapt-contrib-resources/resources.less
@@ -1,5 +1,5 @@
 .resources {
-  &__header {
+  &__header-inner {
     padding: @drawer-item-padding-ver @drawer-item-padding-hoz;
     border-bottom: 1px solid @drawer-item-hover;
   }

--- a/less/plugins/adapt-contrib-resources/resources.less
+++ b/less/plugins/adapt-contrib-resources/resources.less
@@ -4,6 +4,19 @@
     border-bottom: 1px solid @drawer-item-hover;
   }
 
+  &__title {
+    margin-bottom: @drawer-header-title-margin;
+    .drawer-title;
+  }
+
+  &__body {
+    margin-bottom: @drawer-header-body-margin;
+  }
+
+  &__instruction {
+    margin-bottom: @drawer-header-instruction-margin;
+  }
+
   &__filter-btn {
     padding: @item-padding (@item-padding / 2);
     .resources-filter-btn;


### PR DESCRIPTION
Fix #599 

### Fix
* Fixes lack of padding in Resources header
* Adds bottom border to header

### Update
* Adds `@drawer-header-title/body/instruction-margin` spacing variables
* Adds `@drawer-title-*` font variables + `.drawer-title()` mixin (mirrors `.notify-title()`)
* Applies title font/margin, body/instruction margins to Resources header

### Notes
The new drawer-header variables and mixin are reusable by other drawer plugins, but only Resources currently uses the shared `templates.header` [partial](https://github.com/adaptlearning/adapt-contrib-resources/blob/1a343a0320c56dc0c4b4118b594e716bce273fd1/templates/resources.jsx#L51) so only it consumes them.