### PR TITLE
Update: Modernise favicon handling and guidance (fix #601)

### DIFF
--- a/example.json
+++ b/example.json
@@ -4,7 +4,9 @@
 // course.json
 "_vanilla": {
     "_favIcon": {
-        "_src": ""
+        "_src": "",
+        "_svg": "",
+        "_appleTouch": ""
     }
 },
 

--- a/js/theme.js
+++ b/js/theme.js
@@ -20,13 +20,15 @@ class Theme extends Backbone.Controller {
   }
 
   addFavIcon() {
-    const theme = Adapt.course.get('_vanilla');
-    if (!theme?._favIcon?._src) return;
-    const $linkStandard = $(`<link rel="icon" href="${theme._favIcon._src}" size="192x192" />`);
-    const $linkApple = $(`<link rel="apple-touch-icon" href="${theme._favIcon._src}" />`);
-    $('head')
-      .append($linkStandard)
-      .append($linkApple);
+    const favIcon = Adapt.course.get('_vanilla')?._favIcon;
+    if (!favIcon?._src) return;
+    const $head = $('head');
+    if (favIcon._svg) {
+      $head.append($(`<link rel="icon" type="image/svg+xml" href="${favIcon._svg}" />`));
+    }
+    $head.append($(`<link rel="icon" href="${favIcon._src}" />`));
+    const appleSrc = favIcon._appleTouch || favIcon._src;
+    $head.append($(`<link rel="apple-touch-icon" href="${appleSrc}" />`));
   }
 
   onPostRender(view) {

--- a/properties.schema
+++ b/properties.schema
@@ -1233,14 +1233,34 @@
                   "type": "object",
                   "required": false,
                   "legend": "FavIcon",
+                  "help": "Favicons appear in browser tabs, bookmarks, and on mobile devices when learners add your course to their home screen. The Image below is used as the base favicon and as a fallback for the Apple touch icon. Optionally provide an SVG for sharper rendering at any size, or a dedicated Apple touch icon for iOS home screens.",
                   "properties": {
                     "_src": {
                       "type": "string",
                       "required": false,
                       "default": "",
+                      "title": "Image",
                       "inputType": "Asset:image",
                       "validators": [],
-                      "help": "Select a favicon to improve user experience and enforce brand consistency. This will be displayed in places like your browser's address bar, page tabs and bookmarks menu. Usually, a favicon is 16 x 16 pixels in size and stored in the GIF, PNG, or ICO file format."
+                      "help": "Base favicon used in browser tabs and bookmarks. If a separate Apple touch icon is set below, use a 32 x 32 PNG. Otherwise this image is also used as the Apple touch icon, so use a 180 x 180 PNG."
+                    },
+                    "_svg": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "title": "SVG icon",
+                      "inputType": "Asset:image",
+                      "validators": [],
+                      "help": "Optional vector favicon. Modern browsers prefer this over the PNG when set, producing a sharper icon at any size. SVG only."
+                    },
+                    "_appleTouch": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "title": "Apple touch icon",
+                      "inputType": "Asset:image",
+                      "validators": [],
+                      "help": "Optional dedicated icon for iOS home screens. PNG only, 180 x 180 pixels recommended. If empty, the Image above is used."
                     }
                   }
                 }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -17,11 +17,30 @@
               "type": "object",
               "default": {},
               "title": "Favicon",
+              "description": "Favicons appear in browser tabs, bookmarks, and on mobile devices when learners add your course to their home screen. The Image below is used as the base favicon and as a fallback for the Apple touch icon. Optionally provide an SVG for sharper rendering at any size, or a dedicated Apple touch icon for iOS home screens.",
               "properties": {
                 "_src": {
                   "type": "string",
                   "title": "Image",
-                  "description": "Select a favicon to improve user experience and enforce brand consistency. This will be displayed in places like your browser's address bar, page tabs and bookmarks menu. Usually, a favicon is 16 x 16 pixels in size and stored in the GIF, PNG, or ICO file format.",
+                  "description": "Base favicon used in browser tabs and bookmarks. If a separate Apple touch icon is set below, use a 32 x 32 PNG. Otherwise this image is also used as the Apple touch icon, so use a 180 x 180 PNG.",
+                  "_backboneForms": {
+                    "type": "Asset",
+                    "media": "image"
+                  }
+                },
+                "_svg": {
+                  "type": "string",
+                  "title": "SVG icon",
+                  "description": "Optional vector favicon. Modern browsers prefer this over the PNG when set, producing a sharper icon at any size. SVG only.",
+                  "_backboneForms": {
+                    "type": "Asset",
+                    "media": "image"
+                  }
+                },
+                "_appleTouch": {
+                  "type": "string",
+                  "title": "Apple touch icon",
+                  "description": "Optional dedicated icon for iOS home screens. PNG only, 180 x 180 pixels recommended. If empty, the Image above is used.",
                   "_backboneForms": {
                     "type": "Asset",
                     "media": "image"


### PR DESCRIPTION
Fix #601

### Update
- Add optional `_svg` and `_appleTouch` favicon fields
- Refresh schema and `properties.schema` descriptions with current recommendations
- Remove stale `size` attribute on `<link rel="icon">` and emit `type="image/svg+xml"` for the SVG link
- Fall back to the base image for the Apple touch icon when no dedicated icon is provided

### Testing
1. Add to _course.json_:
```json
"_vanilla": {
  "_favIcon": {
    "_src": "course/en/images/favicon.png",
    "_svg": "course/en/images/favicon.svg",
    "_appleTouch": "course/en/images/apple-touch-icon.png"
  }
},
```

2. Inspect the HTML <head> to verify images are correctly assigned.

```html
<link rel="icon" type="image/svg+xml" href="course/en/images/favicon.svg">
<link rel="icon" href="course/en/images/favicon.png">
<link rel="apple-touch-icon" href="course/en/images/apple-touch-icon.png">
```

3. Test fallbacks.
a. Remove the `_svg` value. The browser icon should fall back to the `_src` version. The `image/svg+xml` tag should be removed.
b. Remove the `_appleTouch` value. The app icon should fall back to the `_src` version.

### Images for testing

| **apple-touch-icon.png** | **favicon.png** | **favicon.svg** |
|---|---|---|
| <img width="90" alt="apple-touch-icon" src="https://github.com/user-attachments/assets/a41921ab-3e8e-40ef-80b8-4de751293f88" /> | <img width="90" alt="favicon" src="https://github.com/user-attachments/assets/d780e402-e1fc-4122-9a83-9ad95adb1fec" /> | <img width="90" alt="favicon" src="https://github.com/user-attachments/assets/66dd0d4a-9bbc-47de-8696-a1ad1043e0cd" /> |
