### PR TITLE
Update: Apply associated drawer item locked color variables (fixes #605)

### DIFF
--- a/less/_defaults/_buttonMixins/_drawerItem.less
+++ b/less/_defaults/_buttonMixins/_drawerItem.less
@@ -24,8 +24,8 @@
 }
 
 .drawer-item-color-locked() {
-  background-color: @disabled;
-  color: @disabled-inverted;
+  background-color: @drawer-item-locked;
+  color: @drawer-item-inverted-locked;
   border-color: @drawer-item-hover;
 }
 


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-vanilla/issues/605

### Update
* Apply `@drawer-item-locked` and `@drawer-item-inverted-locked` color variables with the associated button mixin, `.drawer-item-color-locked()`. Instead of using the generic `@disabled` and `@disabled-inverted`.

Note, there is no visual impact from this update as the default values of `@drawer-item-locked` and `@drawer-item-inverted-locked` are the generic `@disabled` and `@disabled-inverted`.



