### PR TITLE
New: Add styling for accordion item button icon position (fixes #607)

### DIFF
--- a/less/plugins/adapt-contrib-accordion/accordion.less
+++ b/less/plugins/adapt-contrib-accordion/accordion.less
@@ -82,6 +82,22 @@
     }
   }
 
+  // Move the toggle icon to the start of the button (default is the end)
+  &.has-icon-left &__btn {
+    padding-inline-start: @icon-size + (@item-padding * 2);
+    padding-inline-end: @item-padding;
+  }
+
+  &.has-icon-left:not(.is-center-aligned) &__icon {
+    right: auto;
+    left: @item-padding;
+
+    .dir-rtl & {
+      left: auto;
+      right: @item-padding;
+    }
+  }
+
   &__content {
     padding: @item-padding;
     border-radius: @item-border-radius;


### PR DESCRIPTION
Fixes #607

### New
Adds Vanilla styling for the Accordion component's new `_iconPosition` option (see adaptlearning/adapt-contrib-accordion#165). When an item carries the `has-icon-left` class, the toggle icon moves to the start of the item button and the button padding flips to suit. The default (`has-icon-right`) is unchanged, so existing courses render exactly as before. RTL is mirrored using the existing `.dir-rtl` pattern.

### Dependencies
Pairs with the Accordion component PR for adaptlearning/adapt-contrib-accordion#165, which adds the `_iconPosition` option and outputs the `has-icon-left`/`has-icon-right` class. The class is the integration point; this PR only supplies the styling.

### Testing
1. Add an accordion to a course and set `"_iconPosition": "left"` on the component.
2. Confirm the toggle (plus/tick) icon renders at the start of each item button, with the title text shifted to make room.
3. Set `"_iconPosition": "right"` (or omit it) and confirm the default, current appearance.
4. Switch the course to an RTL language and confirm the icon mirrors to the opposite side.

Note: combining `_iconPosition: left` with an item `_titleIcon` places both icons at the start of the button, so they overlap. This is an uncommon combination and is out of scope here.

Posted via collaboration with Claude Code