### PR TITLE
New: Add screen-size hide classes aligning with _screenSize (fixes #609)

### DIFF
--- a/less/project/theme-common.less
+++ b/less/project/theme-common.less
@@ -163,7 +163,18 @@
 
 }
 
-// classes to hide content above / below medium breakpoint
+// classes to hide content at a given screen size (aligns with config.json _screenSize)
+// stack classes to hide across multiple sizes, e.g. class="hide-on-small hide-on-medium"
+// --------------------------------------------------
+.size-small .hide-on-small,
+.size-medium .hide-on-medium,
+.size-large .hide-on-large,
+.size-xlarge .hide-on-xlarge {
+  display: none;
+}
+
+// legacy classes, retained for backwards compatibility
+// prefer the screen-size classes above
 // --------------------------------------------------
 .hide-on-desktop {
   @media (min-width: @device-width-medium) {


### PR DESCRIPTION
Fixes #609

### New
- Added screen-size hide classes that align directly with the `_screenSize` names in _config.json_: `hide-on-small`, `hide-on-medium`, `hide-on-large`, and `hide-on-xlarge`. Each hides its element only at that screen size, so the class name states exactly which size it targets.
- To hide across a range of sizes, stack the classes, e.g. `class="hide-on-small hide-on-medium"`.

The existing `hide-on-desktop` and `hide-on-mobile` classes are retained unchanged for backwards compatibility.

### Testing
1. Add `hide-on-small` to a component and confirm it is hidden only at the small screen size, visible at medium and above.
2. Repeat for `hide-on-medium`, `hide-on-large`, and `hide-on-xlarge`.
3. Stack two classes (e.g. `hide-on-small hide-on-medium`) and confirm the element is hidden at both sizes.
4. Confirm existing `hide-on-desktop` / `hide-on-mobile` behaviour is unchanged.

### To-do ☑️
Once merged:

- [x] Update classes on the wiki at https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/Custom-Classes#hide-examples

Posted via collaboration with Claude Code
