### PR TITLE
Update: Add 100% auto and auto 100% options to backgroundSize (fixes #612)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -1331,9 +1331,9 @@
                       "type": "string",
                       "required": false,
                       "default": "cover",
-                      "inputType": {"type":"Select", "options":["auto","cover","contain","100% 100%"]},
+                      "inputType": {"type":"Select", "options":["auto","cover","contain","100% 100%","100% auto","auto 100%"]},
                       "title": "Set the size of the background image",
-                      "help": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container."
+                      "help": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container. 100% auto: Stretch width to fill container, height auto. Auto 100%: Stretch height to fill container, width auto."
                     },
                     "_backgroundPosition": {
                       "type": "string",
@@ -1509,9 +1509,9 @@
                           "type": "string",
                           "required": false,
                           "default": "cover",
-                          "inputType": {"type":"Select", "options":["auto","cover","contain","100% 100%"]},
+                          "inputType": {"type":"Select", "options":["auto","cover","contain","100% 100%","100% auto","auto 100%"]},
                           "title": "Set the size of the background image",
-                          "help": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container."
+                          "help": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container. 100% auto: Stretch width to fill container, height auto. Auto 100%: Stretch height to fill container, width auto."
                         },
                         "_backgroundPosition": {
                           "type": "string",
@@ -1662,9 +1662,9 @@
                       "type": "string",
                       "required": false,
                       "default": "cover",
-                      "inputType": {"type":"Select", "options":["auto","cover","contain","100% 100%"]},
+                      "inputType": {"type":"Select", "options":["auto","cover","contain","100% 100%","100% auto","auto 100%"]},
                       "title": "Set the size of the background image",
-                      "help": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container."
+                      "help": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container. 100% auto: Stretch width to fill container, height auto. Auto 100%: Stretch height to fill container, width auto."
                     },
                     "_backgroundPosition": {
                       "type": "string",
@@ -1807,9 +1807,9 @@
                           "type": "string",
                           "required": false,
                           "default": "cover",
-                          "inputType": {"type":"Select", "options":["auto","cover","contain","100% 100%"]},
+                          "inputType": {"type":"Select", "options":["auto","cover","contain","100% 100%","100% auto","auto 100%"]},
                           "title": "Set the size of the background image",
-                          "help": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container."
+                          "help": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container. 100% auto: Stretch width to fill container, height auto. Auto 100%: Stretch height to fill container, width auto."
                         },
                         "_backgroundPosition": {
                           "type": "string",
@@ -1960,9 +1960,9 @@
                       "type": "string",
                       "required": false,
                       "default": "cover",
-                      "inputType": {"type":"Select", "options":["auto","cover","contain","100% 100%"]},
+                      "inputType": {"type":"Select", "options":["auto","cover","contain","100% 100%","100% auto","auto 100%"]},
                       "title": "Set the size of the background image",
-                      "help": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container."
+                      "help": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container. 100% auto: Stretch width to fill container, height auto. Auto 100%: Stretch height to fill container, width auto."
                     },
                     "_backgroundPosition": {
                       "type": "string",
@@ -2185,9 +2185,9 @@
                           "type": "string",
                           "required": false,
                           "default": "cover",
-                          "inputType": {"type":"Select", "options":["auto","cover","contain","100% 100%"]},
+                          "inputType": {"type":"Select", "options":["auto","cover","contain","100% 100%","100% auto","auto 100%"]},
                           "title": "Set the size of the background image",
-                          "help": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container."
+                          "help": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container. 100% auto: Stretch width to fill container, height auto. Auto 100%: Stretch height to fill container, width auto."
                         },
                         "_backgroundPosition": {
                           "type": "string",

--- a/schema/article.schema.json
+++ b/schema/article.schema.json
@@ -128,13 +128,15 @@
                     "_backgroundSize": {
                       "type": "string",
                       "title": "Size",
-                      "description": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container",
+                      "description": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container. 100% auto: Stretch the image width to fill the container, height scales automatically. Auto 100%: Stretch the image height to fill the container, width scales automatically",
                       "default": "cover",
                       "enum": [
                         "auto",
                         "cover",
                         "contain",
-                        "100% 100%"
+                        "100% 100%",
+                        "100% auto",
+                        "auto 100%"
                       ],
                       "_backboneForms": "Select"
                     },
@@ -255,13 +257,15 @@
                 "_backgroundSize": {
                   "type": "string",
                   "title": "Size",
-                  "description": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container",
+                  "description": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container. 100% auto: Stretch the image width to fill the container, height scales automatically. Auto 100%: Stretch the image height to fill the container, width scales automatically",
                   "default": "cover",
                   "enum": [
                     "auto",
                     "cover",
                     "contain",
-                    "100% 100%"
+                    "100% 100%",
+                    "100% auto",
+                    "auto 100%"
                   ],
                   "_backboneForms": "Select"
                 },

--- a/schema/block.schema.json
+++ b/schema/block.schema.json
@@ -123,13 +123,15 @@
                 "_backgroundSize": {
                   "type": "string",
                   "title": "Size",
-                  "description": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container",
+                  "description": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container. 100% auto: Stretch the image width to fill the container, height scales automatically. Auto 100%: Stretch the image height to fill the container, width scales automatically",
                   "default": "cover",
                   "enum": [
                     "auto",
                     "cover",
                     "contain",
-                    "100% 100%"
+                    "100% 100%",
+                    "100% auto",
+                    "auto 100%"
                   ],
                   "_backboneForms": "Select"
                 },
@@ -222,13 +224,15 @@
                     "_backgroundSize": {
                       "type": "string",
                       "title": "Size",
-                      "description": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container",
+                      "description": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container. 100% auto: Stretch the image width to fill the container, height scales automatically. Auto 100%: Stretch the image height to fill the container, width scales automatically",
                       "default": "cover",
                       "enum": [
                         "auto",
                         "cover",
                         "contain",
-                        "100% 100%"
+                        "100% 100%",
+                        "100% auto",
+                        "auto 100%"
                       ],
                       "_backboneForms": "Select"
                     },

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -77,13 +77,15 @@
                 "_backgroundSize": {
                   "type": "string",
                   "title": "Size",
-                  "description": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container",
+                  "description": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container. 100% auto: Stretch the image width to fill the container, height scales automatically. Auto 100%: Stretch the image height to fill the container, width scales automatically",
                   "default": "cover",
                   "enum": [
                     "auto",
                     "cover",
                     "contain",
-                    "100% 100%"
+                    "100% 100%",
+                    "100% auto",
+                    "auto 100%"
                   ],
                   "_backboneForms": "Select"
                 },
@@ -291,13 +293,15 @@
                     "_backgroundSize": {
                       "type": "string",
                       "title": "Size",
-                      "description": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container",
+                      "description": "Auto: The background image is displayed in its original size. Cover: Resize the background image to cover the entire container, even if it has to stretch or crop the image. Contain: Resize the background image to make sure the image is fully visible. 100% 100%: Resize the background image to match the dimensions of the container. 100% auto: Stretch the image width to fill the container, height scales automatically. Auto 100%: Stretch the image height to fill the container, width scales automatically",
                       "default": "cover",
                       "enum": [
                         "auto",
                         "cover",
                         "contain",
-                        "100% 100%"
+                        "100% 100%",
+                        "100% auto",
+                        "auto 100%"
                       ],
                       "_backboneForms": "Select"
                     },


### PR DESCRIPTION
Fixes #612

### Update
Added `100% auto` and `auto 100%` as additional options for `_backgroundSize` on background images (page, article, and block headers), alongside the existing `auto`, `cover`, `contain`, and `100% 100%` options. This lets a background image stretch to fill one axis while the other scales automatically. Help text updated to describe the new options.

### Testing
1. Set a block/article/page header background image with `_backgroundSize` set to `100% auto` or `auto 100%`.
2. Confirm the image stretches along the specified axis only, with the other axis scaling proportionally.
3. Confirm existing options (`auto`, `cover`, `contain`, `100% 100%`) still behave as before.

Posted via collaboration with Claude Code